### PR TITLE
pyCrypto is mandatory

### DIFF
--- a/ee_plugin/__init__.py
+++ b/ee_plugin/__init__.py
@@ -7,7 +7,7 @@ import site
 if sys.platform == 'win32':
     extlib_path = '/extlibs_windows'
 elif sys.platform == 'darwin':
-    extlib_path = '/extlibs_macos'
+    extlib_path = '/extlibs_darwin'
 else:
     extlib_path = '/extlibs_linux'
 

--- a/ee_plugin/__init__.py
+++ b/ee_plugin/__init__.py
@@ -3,7 +3,14 @@
 import os
 import site
 
-site.addsitedir(os.path.abspath(os.path.dirname(__file__) + '/extlibs'))
+if os.name == 'nt':
+    extlib_path = '/extlibs_windows'
+elif sys.platform == 'darwin':
+    extlib_path = '/extlibs_macos'
+else:
+    extlib_path = '/extlibs_linux'
+
+site.addsitedir(os.path.abspath(os.path.dirname(__file__) + extlib_path))
 
 from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QMessageBox

--- a/ee_plugin/__init__.py
+++ b/ee_plugin/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import site
 
-if os.name == 'nt':
+if sys.platform == 'win32':
     extlib_path = '/extlibs_windows'
 elif sys.platform == 'darwin':
     extlib_path = '/extlibs_macos'

--- a/pavement.py
+++ b/pavement.py
@@ -12,10 +12,19 @@ from collections import defaultdict
 from paver.easy import *
 from paver.doctools import html
 
+def get_extlibs():
+    if os.name == 'nt':
+        return 'ee_plugin/extlibs_windows'
+    elif sys.platform == 'darwin':
+        return 'ee_plugin/extlibs_macos'
+    else:
+        return 'ee_plugin/extlibs_linux'
+
+
 options(
     plugin = Bunch(
         name = 'ee_plugin',
-        ext_libs = path('ee_plugin/extlibs'),
+        ext_libs = path(get_extlibs()),
         source_dir = path('ee_plugin'),
         package_dir = path('.'),
         tests = ['test', 'tests'],


### PR DESCRIPTION
After testing in a clean environment, pyCrypto is mandatory but the `paver setup` command in Linux build fine but in a clean environment in Windows show the same error that you have happened using the first implementation for external libs made by me.

It is possible to extract manually that library using `conda install pyCrypto` but the problem is automating this process (e.g. with travis), we need to find a solution for this.