### PR TITLE
wait to import httplib2 until paths to external libraries are added 

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,17 +4,18 @@ import platform
 import site
 import pkg_resources
 import builtins
-import httplib2
 
 
 def pre_init_plugin():
     if platform.system() == "Windows":
-        extlib_path = 'extlibs_windows'
+        extlib_path = "extlibs_windows"
     if platform.system() == "Darwin":
-        extlib_path = 'extlibs_darwin'
+        extlib_path = "extlibs_darwin"
     if platform.system() == "Linux":
-        extlib_path = 'extlibs_linux'
-    extra_libs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), extlib_path))
+        extlib_path = "extlibs_linux"
+    extra_libs_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), extlib_path)
+    )
 
     # add to python path
     site.addsitedir(extra_libs_path)
@@ -27,19 +28,25 @@ def import_ee():
     purpose of initializing or starting ee authentication when the
     user or the plugin import ee library.
     """
+    # we can now import the libraries
+    # Work around bug https://github.com/google/earthengine-api/issues/181
+    import httplib2
+
     from ee_plugin.ee_auth import authenticate
 
     def __wrapping_ee_import__(name, *args, **kwargs):
         _module_ = __builtin_import__(name, *args, **kwargs)
-        if name == 'ee':
+        if name == "ee":
             if not _module_.data._credentials:
                 try:
                     _module_.Initialize(http_transport=httplib2.Http())
                 except _module_.ee_exception.EEException:
                     if authenticate(ee=_module_):
-                        _module_.Initialize(http_transport=httplib2.Http())  # retry initialization once the user logs in
+                        _module_.Initialize(
+                            http_transport=httplib2.Http()
+                        )  # retry initialization once the user logs in
                     else:
-                        print('\nGoogle Earth Engine authorization failed!\n')
+                        print("\nGoogle Earth Engine authorization failed!\n")
 
         return _module_
 
@@ -63,4 +70,5 @@ def classFactory(iface):  # pylint: disable=invalid-name
 
     # start
     from .ee_plugin import GoogleEarthEnginePlugin
+
     return GoogleEarthEnginePlugin(iface)


### PR DESCRIPTION
This solves an issue related to the initialization. On new installs we can't import httlib2 before it is added to the path. 
https://github.com/gee-community/qgis-earthengine-plugin/issues/105