### PR TITLE
Fix a warning/error of a position argument in read and write native a…

### DIFF
--- a/provider.py
+++ b/provider.py
@@ -303,11 +303,11 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     def setMaxOversampling(self, factor):
         return self.wms.setMaxOversampling(factor)
 
-    def writeNativeAttributeTable(self, errorMessage):
-        return self.wms.writeNativeAttributeTable(errorMessage)
+    def writeNativeAttributeTable(self):
+        return self.wms.writeNativeAttributeTable()
 
-    def readNativeAttributeTable(self, errorMessage):
-        return self.wms.readNativeAttributeTable(errorMessage)
+    def readNativeAttributeTable(self):
+        return self.wms.readNativeAttributeTable()
 
     # readBlock()
 


### PR DESCRIPTION
Fix a warning/error of a position argument in read and write native attribute table:

![image](https://github.com/gee-community/qgis-earthengine-plugin/assets/11801453/a1bacd3d-fd0a-47ca-b386-7a054f686782)

I didn't remember if I'd seen this error/warning before, I think yes but I ignored it, this error doesn't seem to affect the functionality at all but it is better fix it