### PR TITLE
Clarify the instructions at the end of the auth process

### DIFF
--- a/ee_auth.py
+++ b/ee_auth.py
@@ -30,7 +30,8 @@ class MyHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header('Content-type', 'text/plain')
         self.end_headers()
-        self.wfile.write(bytes("QGIS Google Earth Engine plugin authentication finished successfully.", 'utf-8'))
+        self.wfile.write(bytes("Authentication for the QGIS Google Earth Engine plugin has been successfully completed. "
+                               "You may now close this page.", 'utf-8'))
 
 def authenticate(ee=None):
     """


### PR DESCRIPTION
I realized that at the end of Google authentication, the user must close the page to finish the authentication process; otherwise Qgis gets stuck waiting for the user to close the page (at least on Linux). So, it's good to clarify the instructions at the end so that users can close the page.