### PR TITLE
External libraries refactoring

### DIFF
--- a/.github/workflows/qgis-plugin-package.yml
+++ b/.github/workflows/qgis-plugin-package.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7"]
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        python-version: ["3.10"]
+        os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,9 @@ __pycache__
 *.qgs~
 
 help/build
-extlibs_darwin
-extlibs_linux
-extlibs_windows
+extlibs
 media/
 
 *.qgs~
 
+ee_plugin.zip

--- a/__init__.py
+++ b/__init__.py
@@ -1,26 +1,19 @@
 # -*- coding: utf-8 -*-
 import os
-import platform
 import site
 import pkg_resources
 import builtins
 
 
 def pre_init_plugin():
-    if platform.system() == "Windows":
-        extlib_path = "extlibs_windows"
-    if platform.system() == "Darwin":
-        extlib_path = "extlibs_darwin"
-    if platform.system() == "Linux":
-        extlib_path = "extlibs_linux"
-    extra_libs_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), extlib_path)
-    )
 
-    # add to python path
-    site.addsitedir(extra_libs_path)
-    # pkg_resources doesn't listen to changes on sys.path.
-    pkg_resources.working_set.add_entry(extra_libs_path)
+    extra_libs_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'extlibs'))
+
+    if os.path.isdir(extra_libs_path):
+        # add to python path
+        site.addsitedir(extra_libs_path)
+        # pkg_resources doesn't listen to changes on sys.path.
+        pkg_resources.working_set.add_entry(extra_libs_path)
 
 
 def import_ee():

--- a/pavement.py
+++ b/pavement.py
@@ -18,10 +18,14 @@ options(
         excludes=[
             "*.pyc",
             ".git",
+            ".github",
             ".idea",
             ".gitignore",
             ".travis.yml",
             "__pycache__",
+            "docs",
+            "help",
+            "test",
             "media",
             "ee_plugin.zip"
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ratelim
-earthengine-api
+earthengine-api==0.1.335
 six>=1.13
 httplib2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ratelim
-earthengine-api==0.1.335
+earthengine-api>=0.1.335
 six>=1.13
 httplib2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ratelim
-pyCrypto
 earthengine-api
 six>=1.13
 httplib2


### PR DESCRIPTION
- Refactoring the process of generating (paver) and importing (init) the external libraries required by the plugin because it is not strictly OS-dependent: extlibs_OS > extlibs
- Now is enough to have a Github action for only one OS
- Fixes some paver packaging

With this, we are going to reduce the complexity of generating and packaging the external libraries (and package size). We need to check the new extlibs through two tests ( @gena and @SiggyF ? )

| Test | Windows | Linux | Mac |
| ---- | --------- | -------- | ---- |
| GEE Authentication | :white_check_mark: Xavier <br/> tester 2 | :white_check_mark: Xavier <br/> tester 2   | :white_check_mark: SiggyF <br/> tester 2 |
| GEE Example | :white_check_mark: Xavier <br/> tester 2 | :white_check_mark: Xavier <br/> tester 2  |:white_check_mark: SiggyF<br/> tester 2 |

For testing, use the Artifact at https://github.com/gee-community/qgis-earthengine-plugin/actions/runs/8509882708 (the package is created by Ubuntu OS but should work for any OS)