### PR TITLE
Fix/timeout hangs qgis

### DIFF
--- a/ee_plugin.py
+++ b/ee_plugin.py
@@ -134,7 +134,9 @@ class GoogleEarthEnginePlugin(object):
         try:
             # Attempt to get the latest version from the server
             latest_version = requests.get(
-                "https://qgis-ee-plugin.appspot.com/get_latest_version"
+                "https://qgis-ee-plugin.appspot.com/get_latest_version",
+                # requires requests > 2.4, can through requests.exceptions.Timeout (which is a RequestException, so already handled)
+                timeout=10,
             ).text
 
             if VERSION < latest_version:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ratelim
 earthengine-api>=0.1.335
 six>=1.13
 httplib2
+requests>2.4


### PR DESCRIPTION
This PR fixes #188 . Requests 2.4 was released in 2014, added missing dependency in requirements.txt. 

It requires testing using a bad internet connection. I will test it once I have a flaky connection available. 