### PR TITLE
Feature/vector layer

### DIFF
--- a/.github/workflows/qgis-plugin-package.yml
+++ b/.github/workflows/qgis-plugin-package.yml
@@ -35,7 +35,7 @@ jobs:
         paver package
    
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ee_plugin-${{ matrix.os }}.zip
         path: ee_plugin.zip

--- a/ee_plugin/Map.py
+++ b/ee_plugin/Map.py
@@ -13,7 +13,7 @@ from qgis.core import (
     QgsProject,
     QgsRectangle,
 )
-from qgis.PyQt.QtCore import QEventLoop, QTimer
+from qgis.PyQt.QtCore import QEventLoop, QTimer, QCoreApplication, QThread
 from qgis.utils import iface
 
 
@@ -133,8 +133,9 @@ def setCenter(lon, lat, zoom=None):
     # wait 100 milliseconds while load the ee image
     loop = QEventLoop()
     QTimer.singleShot(100, loop.quit)
-    loop.exec_()
-    ### center
+    for _ in range(10):  # Process events for 10 iterations
+        QCoreApplication.processEvents()
+        QThread.msleep(10)  ### center
     center_point_in = QgsPointXY(lon, lat)
     # convert coordinates
     crsSrc = QgsCoordinateReferenceSystem("EPSG:4326")

--- a/ee_plugin/provider.py
+++ b/ee_plugin/provider.py
@@ -53,7 +53,9 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
 
     def __init__(self, uri, providerOptions=None, flags=None, image=None):
         super().__init__()
-
+        self.uri = uri
+        self.providerOptions = providerOptions
+        self.flags = flags
         self.ee_object = image
         self.ee_info = image.getInfo() if image else None
 
@@ -342,7 +344,9 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     # QgsRasterInterface
     # TODO: I believe could be removed. Taken care of upon initialization.
     def clone(self):
-        provider = EarthEngineRasterDataProvider(*self._args, **self._kwargs)
+        provider = EarthEngineRasterDataProvider(
+            self.uri, self.providerOptions, self.flags, self.ee_object
+        )
         provider.wms.setDataSourceUri(self.wms.dataSourceUri())
         provider.set_ee_object(self.ee_object)
         provider.setParent(EarthEngineRasterDataProvider.PARENT)

--- a/ee_plugin/provider.py
+++ b/ee_plugin/provider.py
@@ -17,7 +17,6 @@ from qgis.core import (
     QgsRasterDataProvider,
     QgsRasterIdentifyResult,
     QgsRasterInterface,
-    QgsVectorDataProvider,
 )
 from qgis.PyQt.QtCore import QObject
 
@@ -42,14 +41,6 @@ BAND_TYPES = {
 
 class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     PARENT = QObject()
-
-    # def __getattribute__(self, attr):
-    #     method = object.__getattribute__(self, attr)
-    #     # if not method:
-    #         # raise Exception("Method %s not implemented" % attr)
-    #     if callable(method):
-    #          print(f"method: {attr}")
-    #     return method
 
     def __init__(self, uri, providerOptions=None, flags=None, image=None):
         super().__init__()
@@ -86,9 +77,6 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
             provider.set_ee_object(image)
 
         return provider
-
-    # ============================
-    # QgsDataProvider methods
 
     def crs(self):
         return QgsCoordinateReferenceSystem("EPSG:3857")
@@ -189,8 +177,6 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     def reloadProviderData(self):
         return self.wms.reloadProviderData()
 
-    # # QgsRasterDataProvider
-
     def providerCapabilities(self):
         return self.wms.providerCapabilities()
 
@@ -239,10 +225,6 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     def getLegendGraphicFetcher(self, mapSettings):
         return self.wms.getLegendGraphicFetcher(mapSettings)
 
-    # buildPyramids()
-
-    # buildPyramidList()
-
     def htmlMetadata(self):
         return json.dumps(self.ee_object.getInfo())
 
@@ -281,16 +263,8 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     def setEditable(self, enabled):
         return self.wms.setIsEditable(enabled)
 
-    # write()
-
-    # setNoDataValue()
-
     def remove(self):
         return self.wms.remove()
-
-    # validateCreationOptions()
-
-    # validatePyramidsConfigOptions()
 
     def stepWidth(self):
         return self.wms.stepWidth()
@@ -325,10 +299,6 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     def readNativeAttributeTable(self):
         return self.wms.readNativeAttributeTable()
 
-    # readBlock()
-
-    # QgsWmsProvider
-
     def getMapUrl(self):
         return self.wms.getMapUrl()
 
@@ -341,8 +311,6 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     def getLegendGraphicUrl(self):
         return self.wms.getLegendGraphicUrl()
 
-    # QgsRasterInterface
-    # TODO: I believe could be removed. Taken care of upon initialization.
     def clone(self):
         provider = EarthEngineRasterDataProvider(
             self.uri, self.providerOptions, self.flags, self.ee_object
@@ -413,35 +381,9 @@ class EarthEngineRasterDataProvider(QgsRasterDataProvider):
     def sourceInput(self):
         return self.wms.sourceInput()
 
-    # bandStatistics()
-
-    # hasStatistics()
-
-    # histogram()
-
-    # hasHistogram()
-
-    # cumulativeCut()
-
-    # writeXml()
-
-    # readXml()
-
     def set_ee_object(self, ee_object):
         self.ee_object = ee_object
         self.ee_info = ee_object.getInfo()
-
-
-class EarthEngineVectorDataProvider(QgsVectorDataProvider):
-    pass
-
-
-class EarthEngineRasterCollectionDataProvider(QgsRasterDataProvider):
-    pass
-
-
-class EarthEngineVectorCollectionDataProvider(QgsVectorDataProvider):
-    pass
 
 
 def register_data_provider():

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -24,11 +24,8 @@ def is_named_dataset(eeObject):
 
 
 def get_layer_by_name(name):
-    layers = QgsProject.instance().mapLayers().values()
-
-    for layer in layers:
-        if layer.name() == name:
-            return layer
+    for layer in QgsProject.instance().mapLayersByName(name):
+        return layer
 
     return None
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -152,6 +152,7 @@ def add_or_update_named_vector_layer(
     if not table_id:
         raise ValueError(f"FeatureCollection {name} does not have a valid tableId.")
 
+    # Given the potential large-size of named datasets, we render FeatureCollections as WMS raster layers
     image = ee.Image().paint(eeObject, 0, 2)
     layer = add_or_update_ee_raster_layer(image, name, vis_params, shown, opacity)
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -80,7 +80,13 @@ def add_ee_image_layer(image, name, shown, opacity):
     """
     check_version()
     url = "type=xyz&url=" + get_ee_image_url(image)
+
     layer = QgsRasterLayer(url, name, "EE")
+    assert layer.isValid(), f"Failed to load layer: {name}"
+
+    provider = layer.dataProvider()
+    assert provider is not None, f"Failed to get provider for layer: {name}"
+
     layer.dataProvider().set_ee_object(image)
     qgis_instance = QgsProject.instance()
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -4,87 +4,12 @@ Utils functions GEE
 """
 
 import json
+import tempfile
 
 import ee
 import qgis
-from qgis.core import (
-    QgsProject,
-    QgsRasterLayer,
-)
-
+from qgis.core import QgsProject, QgsRasterLayer, QgsVectorLayer
 from .ee_plugin import VERSION as ee_plugin_version
-
-
-def get_ee_image_url(image):
-    map_id = ee.data.getMapId({"image": image})
-    url = map_id["tile_fetcher"].url_format + "&zmax=25"
-    return url
-
-
-def update_ee_layer_properties(layer, eeObject, visParams, shown, opacity):
-    layer.dataProvider().set_ee_object(eeObject)
-    layer.setCustomProperty("ee-layer", True)
-
-    if opacity is not None:
-        renderer = layer.renderer()
-        if renderer:
-            renderer.setOpacity(opacity)
-
-    # serialize EE code
-    ee_object = eeObject.serialize()
-    ee_object_vis = json.dumps(visParams)
-    layer.setCustomProperty("ee-plugin-version", ee_plugin_version)
-    layer.setCustomProperty("ee-object", ee_object)
-    layer.setCustomProperty("ee-object-vis", ee_object_vis)
-
-    # update EE script in provider
-    if eeObject.getInfo()["type"] == "Image":  # TODO
-        layer.dataProvider().set_ee_object(eeObject)
-
-
-def add_ee_image_layer(image, name, shown, opacity):
-    check_version()
-
-    url = "type=xyz&url=" + get_ee_image_url(image)
-    layer = QgsRasterLayer(url, name, "EE")
-    QgsProject.instance().addMapLayer(layer)
-
-    if shown is not None:
-        QgsProject.instance().layerTreeRoot().findLayer(
-            layer.id()
-        ).setItemVisibilityChecked(shown)
-
-    return layer
-
-
-def update_ee_image_layer(image, layer, shown=True, opacity=1.0):
-    check_version()
-
-    url = "type=xyz&url=" + get_ee_image_url(image)
-
-    root = QgsProject.instance().layerTreeRoot()
-    layer_node = root.findLayer(layer)  # layer is a QgsMapLayer
-    parent_group = layer_node.parent()
-
-    # Get layer index
-    idx = parent_group.children().index(layer_node)
-
-    # new layer
-    layer_new = QgsRasterLayer(url, layer.name(), "EE")
-
-    # Remove old layer
-    QgsProject.instance().removeMapLayers([layer.id()])
-
-    QgsProject.instance().addMapLayer(layer_new, False)
-    root.insertLayer(idx, layer_new)
-
-    layer = layer_new
-
-    item = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
-    if shown is not None:
-        item.setItemVisibilityChecked(shown)
-
-    return layer
 
 
 def get_layer_by_name(name):
@@ -97,67 +22,51 @@ def get_layer_by_name(name):
     return None
 
 
+def get_ee_image_url(image):
+    map_id = ee.data.getMapId({"image": image})
+    url = map_id["tile_fetcher"].url_format + "&zmax=25"
+    return url
+
+
+def update_ee_layer_properties(layer, eeObject, opacity):
+    """
+    Updates the layer properties including opacity.
+    """
+    layer.dataProvider().set_ee_object(eeObject)
+    layer.setCustomProperty("ee-layer", True)
+
+    if opacity is not None and layer.renderer():
+        renderer = layer.renderer()
+        if renderer:
+            renderer.setOpacity(opacity)
+
+    # Serialize EE object
+    layer.setCustomProperty("ee-plugin-version", ee_plugin_version)
+    layer.setCustomProperty("ee-object", eeObject.serialize())
+
+
 def add_or_update_ee_layer(eeObject, visParams, name, shown, opacity):
-    if visParams is None:
-        visParams = {}
-
+    """
+    Entry point to add/update an EE layer. Routes between raster and vector layers.
+    """
     if isinstance(eeObject, ee.Image):
-        image = eeObject.visualize(**visParams)
-
+        image = eeObject.visualize(**visParams)  # Apply visParams here
+        add_or_update_ee_raster_layer(image, name, shown, opacity)
     elif isinstance(
         eeObject, (ee.Geometry, ee.Feature, ee.ImageCollection, ee.FeatureCollection)
     ):
-        features = ee.FeatureCollection(eeObject)
-
-        if "width" in visParams:
-            width = visParams["width"]
-        else:
-            width = 2
-
-        if "color" in visParams:
-            color = visParams["color"]
-        else:
-            color = "000000"
-
-        image_fill = features.style(**{"fillColor": color}).updateMask(
-            ee.Image.constant(0.5)
-        )
-        image_outline = features.style(
-            **{"color": color, "fillColor": "00000000", "width": width}
-        )
-
-        image = image_fill.blend(image_outline)
-
+        add_or_update_ee_vector_layer(eeObject, name, shown, opacity)
     else:
-        err_str = (
-            "\n\nThe image argument in 'addLayer' function must be an instance of one of ee.Image, ee.Geometry, "
-            "ee.Feature, ee.ImageCollection or ee.FeatureCollection."
-        )
-        raise AttributeError(err_str)
-
-    if name is None:
-        # extract name from id
-        try:
-            name = json.loads(eeObject.id().serialize())["scope"][0][1]["arguments"][
-                "id"
-            ]
-        except (AttributeError, KeyError, IndexError, json.JSONDecodeError) as e:
-            print(f"Error extracting name from id: {e}")
-            name = "untitled"
-
-    image.ee_type = type(eeObject)
-
-    layer = add_or_update_ee_image_layer(image, name, shown, opacity)
-    update_ee_layer_properties(layer, eeObject, visParams, shown, opacity)
+        raise TypeError("Unsupported EE object type")
 
 
-def add_or_update_ee_image_layer(image, name, shown=True, opacity=1.0):
+def add_or_update_ee_raster_layer(image, name, shown=True, opacity=1.0):
+    """
+    Adds or updates a raster EE layer.
+    """
     layer = get_layer_by_name(name)
 
-    if layer:
-        if not layer.customProperty("ee-layer"):
-            raise Exception("Layer is not an EE layer: " + name)
-
+    if layer and layer.customProperty("ee-layer"):
         layer = update_ee_image_layer(image, layer, shown, opacity)
     else:
         layer = add_ee_image_layer(image, name, shown, opacity)
@@ -165,17 +74,151 @@ def add_or_update_ee_image_layer(image, name, shown=True, opacity=1.0):
     return layer
 
 
-def add_ee_catalog_image(name, asset_name, visParams, collection_props):
-    image = None
+def add_ee_image_layer(image, name, shown, opacity):
+    """
+    Adds a raster layer using the 'EE' provider.
+    """
+    check_version()
+    url = "type=xyz&url=" + get_ee_image_url(image)
+    layer = QgsRasterLayer(url, name, "EE")
+    layer.dataProvider().set_ee_object(image)
+    qgis_instance = QgsProject.instance()
 
-    if collection_props:
-        raise Exception("Not supported yet")
+    qgis_instance.addMapLayer(layer)
+
+    if opacity is not None and layer.renderer():
+        layer.renderer().setOpacity(opacity)
+
+    if shown is not None:
+        qgis_instance.layerTreeRoot().findLayer(layer.id()).setItemVisibilityChecked(
+            shown
+        )
+
+    return layer
+
+
+def update_ee_image_layer(image, layer, shown=True, opacity=1.0):
+    """
+    Updates an existing EE raster layer.
+    """
+    check_version()
+    url = "type=xyz&url=" + get_ee_image_url(image)
+
+    qgis_instance = QgsProject.instance()
+    root = qgis_instance.layerTreeRoot()
+    layer_node = root.findLayer(layer.id())
+    parent_group = layer_node.parent()
+    idx = parent_group.children().index(layer_node)
+
+    new_layer = QgsRasterLayer(url, layer.name(), "EE")
+
+    if opacity is not None and new_layer.renderer():
+        new_layer.renderer().setOpacity(opacity)
+
+    # Replace the old layer
+    qgis_instance.removeMapLayers([layer.id()])
+    qgis_instance.addMapLayer(new_layer, False)
+    root.insertLayer(idx, new_layer)
+
+    if shown is not None:
+        root.findLayer(new_layer.id()).setItemVisibilityChecked(shown)
+
+    return new_layer
+
+
+def add_or_update_ee_vector_layer(eeObject, name, shown=True, opacity=1.0):
+    """
+    Handles vector layers by converting them to a properly styled GeoJSON vector layer.
+    """
+    layer = get_layer_by_name(name)
+
+    if layer:
+        if not layer.customProperty("ee-layer"):
+            raise Exception(f"Layer is not an EE layer: {name}")
+        layer = update_ee_vector_layer(eeObject, layer, shown, opacity)
     else:
-        image = ee.Image(asset_name).visualize(visParams)
+        layer = add_ee_vector_layer(eeObject, name, shown, opacity)
 
-    add_or_update_ee_image_layer(image, name)
+    return layer
+
+
+def add_ee_vector_layer(eeObject, name, shown=True, opacity=1.0):
+    """
+    Adds a vector layer properly by converting EE Geometry to a valid GeoJSON FeatureCollection.
+    """
+    # Convert EE geometry into a proper GeoJSON FeatureCollection
+    geometry_info = eeObject.getInfo()
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": geometry_info,
+                "properties": {},  # Empty properties
+            }
+        ],
+    }
+
+    # Write to a temporary file for QGIS
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".geojson")
+    with open(temp_file.name, "w") as f:
+        json.dump(geojson, f)
+
+    # Use the temp file as the data source
+    uri = temp_file.name
+
+    # Create the vector layer
+    layer = QgsVectorLayer(uri, name, "ogr")
+
+    if not layer.isValid():
+        print(f"Failed to load vector layer: {name}")
+    else:
+        QgsProject.instance().addMapLayer(layer)
+        if shown is not None:
+            QgsProject.instance().layerTreeRoot().findLayer(
+                layer.id()
+            ).setItemVisibilityChecked(shown)
+        if opacity is not None and layer.renderer():
+            symbol = layer.renderer().symbol()
+            symbol.setOpacity(opacity)
+            layer.triggerRepaint()
+
+    return layer
+
+
+def update_ee_vector_layer(eeObject, layer, shown, opacity):
+    """
+    Updates an existing vector layer with new features from EE.
+    """
+    geojson = eeObject.getInfo()
+    uri = f"GeoJSON?crs=EPSG:4326&url={json.dumps(geojson)}"
+
+    new_layer = QgsVectorLayer(uri, layer.name(), "ogr")
+
+    QgsProject.instance().removeMapLayers([layer.id()])
+    QgsProject.instance().addMapLayer(new_layer)
+
+    if opacity is not None and layer.renderer():
+        new_layer.renderer().setOpacity(opacity)
+
+    if shown is not None:
+        QgsProject.instance().layerTreeRoot().findLayer(
+            new_layer.id()
+        ).setItemVisibilityChecked(shown)
+
+    return new_layer
+
+
+def add_ee_catalog_image(name, asset_name, visParams):
+    """
+    Adds an EE image from a catalog.
+    """
+    image = ee.Image(asset_name).visualize(visParams)
+    add_or_update_ee_raster_layer(image, name)
 
 
 def check_version():
-    # check if we have the latest version only once plugin is used, not once it is loaded
+    """
+    Check if we have the latest plugin version.
+    """
     qgis.utils.plugins["ee_plugin"].check_version()

--- a/test/test_provider.py
+++ b/test/test_provider.py
@@ -34,9 +34,16 @@ def test_raster_identify():
     )
 
     assert raster_identify_result, "Identify operation returned no results"
+    # can't fetch key to match elevation...
+    # but we can verify single band is returned
+    # which was an error caused when we modified the ee.Image to the visualize(**params)
+    # we simply need to pass visualize(**params) to EarthEngine when creating the WMS URL
     assert (
-        raster_identify_result.results()
-    ), "Identify operation returned an empty result set"
+        raster_identify_result.isValid()
+    ), "Identify operation returned an invalid result"
+    assert (
+        len(raster_identify_result.results()) == 1
+    ), "Identify operation returned more than one result, which means multiples bands were returned"
     assert (
         raster_identify_result.results()[1] > 0
     ), "Identified elevation is not positive"

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -43,7 +43,7 @@ geometries = [
 @pytest.mark.parametrize("geometry, vis_params, layer_name", geometries)
 def test_add_geometry_layer(geometry, vis_params, layer_name):
     qgis_instance = QgsProject.instance()
-    Map.addLayer(geometry, vis_params, layer_name), "Layer added successfully"
+    Map.addLayer(geometry, vis_params, layer_name)
 
     layers = qgis_instance.mapLayersByName(layerName=layer_name)
     assert len(layers) == 1, "Wrong number of layers added"
@@ -52,3 +52,18 @@ def test_add_geometry_layer(geometry, vis_params, layer_name):
     assert layer, "Layer not found"
     assert layer.name() == layer_name, "Layer name mismatch"
     assert layer.type() == QgsMapLayer.VectorLayer, "Layer is not a vector layer"
+
+
+def test_data_catalog_vector_layer():
+    qgis_instance = QgsProject.instance()
+
+    ecoregions = ee.FeatureCollection("RESOLVE/ECOREGIONS/2017")
+
+    Map.addLayer(ecoregions, {}, "ecoregions")
+
+    layers = qgis_instance.mapLayersByName(layerName="ecoregions")
+    assert len(layers) == 1, "Wrong number of layers added"
+    assert layers[0].name() == "ecoregions", "Layer name mismatch"
+    assert (
+        layers[0].type() == QgsMapLayer.RasterLayer
+    ), "Layer is treated as raster layer"

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -1,5 +1,6 @@
 import ee
 import pytest
+from qgis.core import QgsMapLayer, QgsProject
 
 from ee_plugin import Map
 
@@ -41,4 +42,13 @@ geometries = [
 
 @pytest.mark.parametrize("geometry, vis_params, layer_name", geometries)
 def test_add_geometry_layer(geometry, vis_params, layer_name):
+    qgis_instance = QgsProject.instance()
     Map.addLayer(geometry, vis_params, layer_name), "Layer added successfully"
+
+    layers = qgis_instance.mapLayersByName(layerName=layer_name)
+    assert len(layers) == 1, "Wrong number of layers added"
+
+    layer = layers[0]
+    assert layer, "Layer not found"
+    assert layer.name() == layer_name, "Layer name mismatch"
+    assert layer.type() == QgsMapLayer.VectorLayer, "Layer is not a vector layer"


### PR DESCRIPTION
### **What I changed**
- Refactored `utils.py` to properly distinguish between vector and raster layers when adding them to the map.
- By the previous point, support the identify tool for vector layers by default.
- Ensured that `visParams` were correctly handled for raster layers to maintain expected visualization behavior.
- Fixed an issue where raster layers returned RGB values instead of elevation data when using Identify.
- Refactored `utils.py` to properly distinguish between vector and raster layers when adding them to the map.
- Also included a quick fix to the deprecation notice on Action Artifacts v3
- Added support to visualize larger vector datasets via EarthEngine as tiles (treated as a raster layer)

### **How to test it**
1. Run unit tests (see CI)
2. **Load a DEM raster layer** (e.g., `USGS/SRTMGL1_003`) and verify that the Identify tool returns **elevation values** instead of RGB.
3. **Load a vector layer** and use the Identify tool to ensure it returns correct feature attributes.
4. **Check visualization**: Confirm that raster layers still respect the `visParams` settings and display as expected.

### **Other notes**
- Closes #60 
- Closes #216 
- Closes #218 (quick fix included here)
- Closes #219 
- Closes #213
