### PR TITLE
Display project ID in toolbars

### DIFF
--- a/ee_plugin/__init__.py
+++ b/ee_plugin/__init__.py
@@ -38,11 +38,9 @@ def classFactory(iface):  # pylint: disable=invalid-name
         ee.data.setUserAgent(user_agent)
 
     # authenticate and initialize EE
-    from . import ee_auth
+    from . import ee_auth, config, ee_plugin
 
-    ee_auth.authenticate_and_set_project()
-
-    # start
-    from .ee_plugin import GoogleEarthEnginePlugin
-
-    return GoogleEarthEnginePlugin(iface)
+    ee_config = config.EarthEngineConfig()
+    ee_auth.ensure_authenticated(ee_config)
+    ee_auth.ee_initialize_with_project(ee_config)
+    return ee_plugin.GoogleEarthEnginePlugin(iface, ee_config=ee_config)

--- a/ee_plugin/config.py
+++ b/ee_plugin/config.py
@@ -10,14 +10,14 @@ class EarthEngineConfigDict(TypedDict):
     project: str
 
 
-class ConfigSignals(QObject):
+class _ConfigSignals(QObject):
     project_changed = pyqtSignal()
 
 
 @dataclass
 class EarthEngineConfig:
     credentials_path: str = field(default_factory=ee.oauth.get_credentials_path)
-    signals: ConfigSignals = field(default_factory=ConfigSignals, init=False)
+    signals: _ConfigSignals = field(default_factory=_ConfigSignals, init=False)
 
     def read(self) -> Optional[EarthEngineConfigDict]:
         """Read the credentials file."""
@@ -47,6 +47,3 @@ class EarthEngineConfig:
         config = self.read()
         if config:
             return config.get("project")
-
-
-ee_config = EarthEngineConfig()

--- a/ee_plugin/config.py
+++ b/ee_plugin/config.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass, field
+import json
+from typing import TypedDict, Optional
+
+import ee
+from qgis.PyQt.QtCore import QObject, pyqtSignal
+
+
+class EarthEngineConfigDict(TypedDict):
+    project: str
+
+
+class ConfigSignals(QObject):
+    project_changed = pyqtSignal()
+
+
+@dataclass
+class EarthEngineConfig:
+    credentials_path: str = field(default_factory=ee.oauth.get_credentials_path)
+    signals: ConfigSignals = field(default_factory=ConfigSignals, init=False)
+
+    def read(self) -> Optional[EarthEngineConfigDict]:
+        """Read the credentials file."""
+        try:
+            with open(self.credentials_path) as json_config_file:
+                return json.load(json_config_file)
+        except FileNotFoundError:
+            return None
+
+    def save_project(self, project: str) -> None:
+        """Save project to the credentials file."""
+        current_config = self.read() or {}
+        if current_config.get("project") == project:
+            return
+        ee.oauth.write_private_json(
+            self.credentials_path,
+            {
+                **current_config,
+                "project": project,
+            },
+        )
+        self.signals.project_changed.emit()
+
+    @property
+    def project_id(self) -> Optional[str]:
+        """Get the current project ID."""
+        config = self.read()
+        if config:
+            return config.get("project")
+
+
+ee_config = EarthEngineConfig()

--- a/ee_plugin/ee_auth.py
+++ b/ee_plugin/ee_auth.py
@@ -1,5 +1,6 @@
-import ee
 from typing import Optional
+
+import ee
 from qgis.PyQt.QtWidgets import QInputDialog, QLineEdit, QMessageBox
 
 from .config import EarthEngineConfig

--- a/ee_plugin/ee_auth.py
+++ b/ee_plugin/ee_auth.py
@@ -7,7 +7,7 @@ from .config import EarthEngineConfig
 
 
 def ee_authenticate(ee_config: EarthEngineConfig) -> bool:
-    """show a dialog to allow users to start or cancel the authentication process"""
+    """Show a dialog to allow users to start or cancel the authentication process"""
 
     msg = """This plugin uses Google Earth Engine API and it looks like it is not yet authenticated on this machine.<br>
     <br>
@@ -38,7 +38,10 @@ def ee_authenticate(ee_config: EarthEngineConfig) -> bool:
 
 
 def ee_initialize_with_project(ee_config: EarthEngineConfig, force=False) -> None:
-    """Initializes EE with a project or ask user to specify project if there is no project set"""
+    """
+    Initialize EE with current project, possibly asking user to specify project if no
+    project currently set in configuration or if we force the prompt
+    """
     project_id = ee_config.project_id
 
     if not project_id or force:
@@ -51,7 +54,7 @@ def ee_initialize_with_project(ee_config: EarthEngineConfig, force=False) -> Non
 
 
 def prompt_for_project(cur_project: Optional[str]) -> Optional[str]:
-    """Prompt user to specify project"""
+    """Show a dialog to prompt user to specify project"""
 
     msg_no_project = """Google Cloud Project is empty.<br>
     <br>
@@ -78,7 +81,9 @@ def prompt_for_project(cur_project: Optional[str]) -> Optional[str]:
 
 
 def ensure_authenticated(ee_config: EarthEngineConfig) -> None:
-    """Ensure that the user is authenticated with Earth Engine"""
+    """
+    Ensure that the user is authenticated with Earth Engine, throwing an exception if not.
+    """
     # Trigger authentication if there is no config (ie not authenticated)
     if not ee_config.read():
         auth_success = ee_authenticate(ee_config)

--- a/ee_plugin/ee_auth.py
+++ b/ee_plugin/ee_auth.py
@@ -42,7 +42,7 @@ def ee_initialize_with_project(ee_config: EarthEngineConfig, force=False) -> Non
     Initialize EE with current project, possibly asking user to specify project if no
     project currently set in configuration or if we force the prompt
     """
-    project_id = ee_config.project_id
+    project_id = ee_config.project
 
     if not project_id or force:
         project_id = prompt_for_project(project_id)
@@ -50,7 +50,7 @@ def ee_initialize_with_project(ee_config: EarthEngineConfig, force=False) -> Non
             return
 
     ee.Initialize(project=project_id)
-    ee_config.save_project(project_id)
+    ee_config.project = project_id
 
 
 def prompt_for_project(cur_project: Optional[str]) -> Optional[str]:

--- a/ee_plugin/ee_plugin.py
+++ b/ee_plugin/ee_plugin.py
@@ -74,9 +74,7 @@ class GoogleEarthEnginePlugin(object):
         provider.register_data_provider()
 
         # Reload the plugin when the config changes
-        self.ee_config.signals.project_changed.connect(
-            self._refresh_project_id
-        )
+        self.ee_config.signals.project_changed.connect(self._refresh_project_id)
 
     # noinspection PyMethodMayBeStatic
     def tr(self, message):
@@ -108,7 +106,7 @@ class GoogleEarthEnginePlugin(object):
             parent=self.iface.mainWindow(),
             triggered=self._run_cmd_sign_in,
         )
-        set_cloud_project_action = QtWidgets.QAction(
+        self.set_cloud_project_action = QtWidgets.QAction(
             icon=icon("google-cloud-project.svg"),
             text=self.tr(self._project_button_text),
             parent=self.iface.mainWindow(),
@@ -125,7 +123,7 @@ class GoogleEarthEnginePlugin(object):
         ee_menu.addAction(ee_user_guide_action)
         ee_menu.addSeparator()
         ee_menu.addAction(sign_in_action)
-        ee_menu.addAction(set_cloud_project_action)
+        ee_menu.addAction(self.set_cloud_project_action)
 
         # Build toolbar
         toolButton = QtWidgets.QToolButton()
@@ -141,7 +139,7 @@ class GoogleEarthEnginePlugin(object):
         toolButton.menu().addAction(ee_user_guide_action)
         toolButton.menu().addSeparator()
         toolButton.menu().addAction(sign_in_action)
-        toolButton.menu().addAction(set_cloud_project_action)
+        toolButton.menu().addAction(self.set_cloud_project_action)
         self.iface.pluginToolBar().addWidget(toolButton)
         self.toolButton = toolButton
 
@@ -162,9 +160,7 @@ class GoogleEarthEnginePlugin(object):
 
     def _refresh_project_id(self):
         """Refresh the text for the project button."""
-        self.cmd_set_cloud_project.setText(
-          self.tr(self._project_button_text)
-        )
+        self.set_cloud_project_action.setText(self.tr(self._project_button_text))
 
     def _run_cmd_ee_user_guide(self):
         # open user guide in external web browser

--- a/ee_plugin/ee_plugin.py
+++ b/ee_plugin/ee_plugin.py
@@ -69,9 +69,7 @@ class GoogleEarthEnginePlugin(object):
         provider.register_data_provider()
 
         # Reload the plugin when the config changes
-        self.ee_config.signals.project_changed.connect(
-            self._refresh_project_button_text
-        )
+        self.ee_config.signals.project_changed.connect(self._refresh_project_id)
 
     # noinspection PyMethodMayBeStatic
     def tr(self, message):
@@ -124,7 +122,7 @@ class GoogleEarthEnginePlugin(object):
         """Get the text for the project button."""
         return f"Set Project: {self.ee_config.project_id or '...'}"
 
-    def _refresh_project_button_text(self):
+    def _refresh_project_id(self):
         """Refresh the text for the project button."""
         self.cmd_set_cloud_project.setText(self._project_button_text)
 

--- a/ee_plugin/ee_plugin.py
+++ b/ee_plugin/ee_plugin.py
@@ -74,7 +74,7 @@ class GoogleEarthEnginePlugin(object):
         provider.register_data_provider()
 
         # Reload the plugin when the config changes
-        self.ee_config.signals.project_changed.connect(self._refresh_project_id)
+        self.ee_config.signals.updated.connect(self._handle_updated_config)
 
     # noinspection PyMethodMayBeStatic
     def tr(self, message):
@@ -156,9 +156,9 @@ class GoogleEarthEnginePlugin(object):
     @property
     def _project_button_text(self):
         """Get the text for the project button."""
-        return f"Set Project: {self.ee_config.project_id or '...'}"
+        return f"Set Project: {self.ee_config.project or '...'}"
 
-    def _refresh_project_id(self):
+    def _handle_updated_config(self):
         """Refresh the text for the project button."""
         self.set_cloud_project_action.setText(self.tr(self._project_button_text))
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,7 @@ from pytest import fixture
 from qgis.utils import plugins
 from PyQt5.QtCore import QSettings, QCoreApplication
 
-from ee_plugin.ee_plugin import GoogleEarthEnginePlugin
+from ee_plugin import ee_plugin, config
 
 
 @fixture(scope="session", autouse=True)
@@ -15,7 +15,12 @@ def setup_ee():
 
 
 @fixture(scope="session", autouse=True)
-def load_ee_plugin(qgis_app, setup_ee):
+def ee_config():
+    return config.EarthEngineConfig()
+
+
+@fixture(scope="session", autouse=True)
+def load_ee_plugin(qgis_app, setup_ee, ee_config):
     """Load Earth Engine plugin and configure QSettings."""
 
     # Set QSettings values required by the plugin
@@ -24,7 +29,7 @@ def load_ee_plugin(qgis_app, setup_ee):
     QSettings().setValue("locale/userLocale", "en")
 
     # Initialize and register the plugin
-    plugin = GoogleEarthEnginePlugin(qgis_app)
+    plugin = ee_plugin.GoogleEarthEnginePlugin(qgis_app, ee_config=ee_config)
     plugins["ee_plugin"] = plugin
     plugin.check_version()
     yield qgis_app

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,12 +1,49 @@
 import json
-from tempfile import TemporaryFile
+from tempfile import NamedTemporaryFile
+from mock import MagicMock
+
+import pytest
 
 from ee_plugin import config
 
 
-def test_config():
-    with TemporaryFile("w") as f:
+@pytest.fixture
+def conf():
+    with NamedTemporaryFile(mode="w") as f:
         json.dump({"project": "qgis-testing"}, f)
-        conf = config.EarthEngineConfig(credentials_path=f.name)
+        f.flush()
+        yield config.EarthEngineConfig(credentials_path=f.name)
 
-        assert conf.project_id == "qgis-testing", "Project ID not set correctly."
+
+def test_config_read_project(conf: config.EarthEngineConfig):
+    """
+    Ensure project ID correctly read from the credentials file.
+    """
+    assert conf.project == "qgis-testing", "Project ID not set correctly."
+
+
+def test_config_write_project(conf: config.EarthEngineConfig):
+    """
+    Ensure project ID correctly written to the credentials file.
+    """
+    conf.project = "new-project"
+    assert conf.project == "new-project", "Project ID not set correctly."
+    with open(conf.credentials_path, "r") as f:
+        assert (
+            json.load(f)["project"] == "new-project"
+        ), "Project ID not written correctly."
+
+
+def test_config_project_signal(conf: config.EarthEngineConfig):
+    """
+    Ensure signal emitted when project written to the credentials file.
+    """
+    m = MagicMock()
+
+    conf.signals.updated.connect(m)
+
+    m.assert_not_called(), "Signal emitted before change."
+
+    conf.project = "new-project"
+
+    m.assert_called_once_with({"project": "new-project"}), "Signal not emitted."

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,12 @@
+import json
+from tempfile import TemporaryFile
+
+from ee_plugin import config
+
+
+def test_config():
+    with TemporaryFile("w") as f:
+        json.dump({"project": "qgis-testing"}, f)
+        conf = config.EarthEngineConfig(credentials_path=f.name)
+
+        assert conf.project_id == "qgis-testing", "Project ID not set correctly."

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,6 +1,6 @@
 import json
 from tempfile import NamedTemporaryFile
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
# What I'm changing

This PR adds the currently set project ID in the menu bar / tool bar.

<img width="299" alt="image" src="https://github.com/user-attachments/assets/3a36624e-a67d-482d-bf47-1d601f3be3cc" />
<img width="536" alt="image" src="https://github.com/user-attachments/assets/fa6a8bf5-4254-4edc-a60f-8eeb2598f094" />

# How I did it

Placing a string in the menus is trivial. However, updating the string when the value is changed is a bit more involved as the plugin is not designed to be reactive to configuration changes.  To add reactive behavior, I've refactored the configuration tooling into a single class that integrates with [QT's Signals tooling](https://doc.qt.io/qt-5/signalsandslots.html).  When the EE plugin initializes itself, it subscribes to the configuration signal and reloads the GUI on changes to the project ID.  This reload only triggers when the configuration alteration occurs via the plugin; it would be possible to watch the file instead and trigger a refresh when the file on disk is altered. However, I worried that such a feature could cause more confusion than value.

---

closes #222