### PR TITLE
Normalize imports

### DIFF
--- a/ee_plugin/ee_plugin.py
+++ b/ee_plugin/ee_plugin.py
@@ -18,8 +18,9 @@ from qgis.core import QgsProject
 from qgis.PyQt import QtWidgets
 from qgis.PyQt.QtCore import QCoreApplication, QSettings, QTranslator, qVersion, Qt
 from qgis.PyQt.QtGui import QIcon
+import ee
 
-from .config import EarthEngineConfig
+from . import provider, config, ee_auth, utils
 
 
 PLUGIN_DIR = os.path.dirname(__file__)
@@ -39,9 +40,9 @@ def icon(icon_name: str) -> QIcon:
 class GoogleEarthEnginePlugin(object):
     """QGIS Plugin Implementation."""
 
-    ee_config: EarthEngineConfig
+    ee_config: config.EarthEngineConfig
 
-    def __init__(self, iface: gui.QgisInterface, ee_config: EarthEngineConfig):
+    def __init__(self, iface: gui.QgisInterface, ee_config: config.EarthEngineConfig):
         """Constructor.
 
         :param iface: An interface instance that will be passed to this class
@@ -49,7 +50,6 @@ class GoogleEarthEnginePlugin(object):
             application at run time.
         :type iface: QgsInterface
         """
-        from . import provider
 
         # Save reference to the QGIS interface
         self.iface = iface
@@ -176,8 +176,6 @@ class GoogleEarthEnginePlugin(object):
         self.run_cmd_set_cloud_project()
 
     def _run_cmd_set_cloud_project(self):
-        from ee_plugin import ee_auth  # type: ignore
-
         ee_auth.ee_initialize_with_project(self.ee_config, force=True)
 
     def check_version(self):
@@ -212,10 +210,6 @@ class GoogleEarthEnginePlugin(object):
             version_checked = True
 
     def _updateLayers(self):
-        import ee
-
-        from .utils import add_or_update_ee_layer
-
         layers = QgsProject.instance().mapLayers().values()
 
         for layer in filter(lambda layer: layer.customProperty("ee-layer"), layers):
@@ -248,4 +242,4 @@ class GoogleEarthEnginePlugin(object):
             )
             opacity = layer.renderer().opacity()
 
-            add_or_update_ee_layer(ee_object, ee_object_vis, name, shown, opacity)
+            utils.add_or_update_ee_layer(ee_object, ee_object_vis, name, shown, opacity)

--- a/ee_plugin/provider.py
+++ b/ee_plugin/provider.py
@@ -20,7 +20,7 @@ from qgis.core import (
 )
 from qgis.PyQt.QtCore import QObject
 
-from ee_plugin import Map
+from . import Map
 
 BAND_TYPES = {
     "int8": Qgis.Int16,

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -9,7 +9,6 @@ import tempfile
 import ee
 import qgis
 from qgis.core import QgsProject, QgsRasterLayer, QgsVectorLayer
-from .ee_plugin import VERSION as ee_plugin_version
 
 
 def is_named_dataset(eeObject):
@@ -34,23 +33,6 @@ def get_ee_image_url(image):
     map_id = ee.data.getMapId({"image": image})
     url = map_id["tile_fetcher"].url_format + "&zmax=25"
     return url
-
-
-def update_ee_layer_properties(layer, eeObject, opacity):
-    """
-    Updates the layer properties including opacity.
-    """
-    layer.dataProvider().set_ee_object(eeObject)
-    layer.setCustomProperty("ee-layer", True)
-
-    if opacity is not None and layer.renderer():
-        renderer = layer.renderer()
-        if renderer:
-            renderer.setOpacity(opacity)
-
-    # Serialize EE object
-    layer.setCustomProperty("ee-plugin-version", ee_plugin_version)
-    layer.setCustomProperty("ee-object", eeObject.serialize())
 
 
 def add_or_update_ee_layer(eeObject, vis_params, name, shown, opacity):


### PR DESCRIPTION
This PR is a quick refactor to normalize how imports occur within this plugin.  I'm not aware of any advantage of delaying imports until methods are called within this codebase. Often this technique is used to avoid circular dependencies, however that in itself is a code-smell that indicates incorrectly organized code.  By removing the unused `update_ee_layer_properties` function, we eliminate any circular dependencies and are thus able to use a standard import pattern.