### PR TITLE
Normalize imports

### DIFF
--- a/ee_plugin/Map.py
+++ b/ee_plugin/Map.py
@@ -23,6 +23,8 @@ def get_iface() -> gui.QgisInterface:
     # Lazy import to ensure that iface is available after gqis is initialized
     from qgis.utils import iface
 
+    if not iface:
+        raise ImportError("QGIS interface not available. Has QGIS been initialized?")
     return iface
 
 

--- a/ee_plugin/Map.py
+++ b/ee_plugin/Map.py
@@ -13,8 +13,17 @@ from qgis.core import (
     QgsProject,
     QgsRectangle,
 )
+from qgis import gui
 from qgis.PyQt.QtCore import QEventLoop, QTimer, QCoreApplication, QThread
-from qgis.utils import iface
+
+from . import utils
+
+
+def get_iface() -> gui.QgisInterface:
+    # Lazy import to ensure that iface is available after gqis is initialized
+    from qgis.utils import iface
+
+    return iface
 
 
 def addLayer(eeObject, visParams=None, name=None, shown=True, opacity=1.0):
@@ -27,8 +36,6 @@ def addLayer(eeObject, visParams=None, name=None, shown=True, opacity=1.0):
         >>> from ee_plugin import Map
         >>> Map.addLayer(.....)
     """
-    from . import utils
-
     utils.add_or_update_ee_layer(eeObject, visParams, name, shown, opacity)
 
 
@@ -67,6 +74,7 @@ def centerObject(feature, zoom=None):
         rect_proj = geo2proj.transform(rect)
 
         # center geometry
+        iface = get_iface()
         iface.mapCanvas().zoomToFeatureExtent(rect_proj)
     else:
         # set map center to feature centroid at a specified zoom
@@ -85,6 +93,7 @@ def getBounds(asGeoJSON=False):
         >>> bounds = Map.getBounds(True)
         >>> Map.addLayer(bounds, {}, 'bounds')
     """
+    iface = get_iface()
     ex = iface.mapCanvas().extent()
     # return ex
     xmax = ex.xMaximum()
@@ -113,6 +122,7 @@ def getCenter():
         >>> center = Map.getCenter()
         >>> Map.addLayer(center, { 'color': 'red' }, 'center')
     """
+    iface = get_iface()
     center = iface.mapCanvas().center()
 
     crs = iface.mapCanvas().mapSettings().destinationCrs().authid()
@@ -143,6 +153,8 @@ def setCenter(lon, lat, zoom=None):
     xform = QgsCoordinateTransform(crsSrc, crsDest, QgsProject.instance())
     # forward transformation: src -> dest
     center_point = xform.transform(center_point_in)
+
+    iface = get_iface()
     iface.mapCanvas().setCenter(center_point)
 
     ### zoom
@@ -162,7 +174,7 @@ def getScale():
         >>> from ee_plugin import Map
         >>> print(Map.getScale())
     """
-
+    iface = get_iface()
     return iface.mapCanvas().scale() / 1000
 
 
@@ -180,6 +192,7 @@ def getZoom():
     """
 
     # from https://gis.stackexchange.com/questions/268890/get-current-zoom-level-from-qgis-map-canvas
+    iface = get_iface()
     scale = iface.mapCanvas().scale()
     dpi = iface.mainWindow().physicalDpiX()
     maxScalePerPixel = 156543.04

--- a/ee_plugin/ee_plugin.py
+++ b/ee_plugin/ee_plugin.py
@@ -18,8 +18,9 @@ from qgis.core import QgsProject
 from qgis.PyQt import QtWidgets
 from qgis.PyQt.QtCore import QCoreApplication, QSettings, QTranslator, qVersion, Qt
 from qgis.PyQt.QtGui import QIcon
+import ee
 
-from .config import EarthEngineConfig
+from . import provider, config, ee_auth, utils
 
 
 PLUGIN_DIR = os.path.dirname(__file__)
@@ -39,9 +40,9 @@ def icon(icon_name: str) -> QIcon:
 class GoogleEarthEnginePlugin(object):
     """QGIS Plugin Implementation."""
 
-    ee_config: EarthEngineConfig
+    ee_config: config.EarthEngineConfig
 
-    def __init__(self, iface: gui.QgisInterface, ee_config: EarthEngineConfig):
+    def __init__(self, iface: gui.QgisInterface, ee_config: config.EarthEngineConfig):
         """Constructor.
 
         :param iface: An interface instance that will be passed to this class
@@ -49,7 +50,6 @@ class GoogleEarthEnginePlugin(object):
             application at run time.
         :type iface: QgsInterface
         """
-        from . import provider
 
         # Save reference to the QGIS interface
         self.iface = iface
@@ -176,8 +176,6 @@ class GoogleEarthEnginePlugin(object):
         self.run_cmd_set_cloud_project()
 
     def _run_cmd_set_cloud_project(self):
-        from ee_plugin import ee_auth  # type: ignore
-
         ee_auth.ee_initialize_with_project(self.ee_config, force=True)
 
     def check_version(self):
@@ -212,10 +210,6 @@ class GoogleEarthEnginePlugin(object):
             version_checked = True
 
     def _updateLayers(self):
-        import ee
-
-        from .utils import add_or_update_ee_layer
-
         layers = QgsProject.instance().mapLayers().values()
 
         for layer in filter(lambda layer: layer.customProperty("ee-layer"), layers):
@@ -248,4 +242,4 @@ class GoogleEarthEnginePlugin(object):
             )
             opacity = layer.renderer().opacity()
 
-            add_or_update_ee_layer(ee_object, ee_object_vis, name, shown, opacity)
+            utils.add_or_update_ee_layer(ee_object, ee_object_vis, name, shown, opacity)

--- a/ee_plugin/provider.py
+++ b/ee_plugin/provider.py
@@ -20,7 +20,7 @@ from qgis.core import (
 )
 from qgis.PyQt.QtCore import QObject
 
-from ee_plugin import Map
+from . import Map
 
 BAND_TYPES = {
     "int8": Qgis.Int16,

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -9,7 +9,6 @@ import tempfile
 import ee
 import qgis
 from qgis.core import QgsProject, QgsRasterLayer, QgsVectorLayer
-from .ee_plugin import VERSION as ee_plugin_version
 
 
 def is_named_dataset(eeObject):
@@ -34,23 +33,6 @@ def get_ee_image_url(image):
     map_id = ee.data.getMapId({"image": image})
     url = map_id["tile_fetcher"].url_format + "&zmax=25"
     return url
-
-
-def update_ee_layer_properties(layer, eeObject, opacity):
-    """
-    Updates the layer properties including opacity.
-    """
-    layer.dataProvider().set_ee_object(eeObject)
-    layer.setCustomProperty("ee-layer", True)
-
-    if opacity is not None and layer.renderer():
-        renderer = layer.renderer()
-        if renderer:
-            renderer.setOpacity(opacity)
-
-    # Serialize EE object
-    layer.setCustomProperty("ee-plugin-version", ee_plugin_version)
-    layer.setCustomProperty("ee-object", eeObject.serialize())
 
 
 def add_or_update_ee_layer(eeObject, vis_params, name, shown, opacity):

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -1,10 +1,9 @@
 from ee_plugin import Map
+import ee
 
 
 def test_add_layer():
     """Test adding a layer to the map."""
-    import ee
-
     image = ee.Image("USGS/SRTMGL1_003")
     vis_params = {
         "min": 0,


### PR DESCRIPTION
This PR is a quick refactor to normalize how imports occur within this plugin, moving all imports to the top of the files. I'm unaware of any advantage of delaying imports until methods are called within this codebase. Delayed imports are often used to avoid circular dependencies; however, that is a code smell that indicates incorrectly organized code.  By removing the unused `update_ee_layer_properties` function, we eliminate any circular dependencies and are thus able to use a standard import pattern.  

One exception to this is when retrieving the `iface` object in `Map.py`, wherein we must only import it _after_ QGIS has initialized as it is initially set to `None` and then later replaced with the proper interface instance. I believe the only time in which it's possible to import it when it is in its `None` state is within testing environments. Moving the import to a `get_iface()` function also comes with the advantage of typing the value, which is not available in its native form.