### PR TITLE
Remove pytest-qgis dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,8 @@
 -r requirements.txt  # Include all main requirements
 
 # Development dependencies
-pytest==7.4.3 # pytest-qgis does not support pytest>=8
+pytest==8.3.5 
 pytest-cov
-pytest-qgis==2.1.0
 pre-commit
 pyqt5
 future


### PR DESCRIPTION
## What I Changed

- Remove `pytest-qgis` from dependencies

## How to test it

- See CI/run tests locally

## Other notes

I tried using the fixtures again, and they have null references. We built our whole test suite without `pytest-qgis`, and it seems we would be adding significant overhead to add maintenance of it. All of our tests pass without it; I think we should remove the dependency.