### PR TITLE
Move pandas and rasterio to dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,4 @@ pre-commit
 pyqt5
 future
 paver
-pandas
 rasterio

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,5 @@ pre-commit
 pyqt5
 future
 paver
+pandas
+rasterio

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ earthengine-api>=0.1.335
 six>=1.13
 httplib2
 requests>2.4
-pandas
-rasterio


### PR DESCRIPTION
Pandas and rasterio are only used for our automated tests. Removing reduces the plugin size.