### PR TITLE
Add LICENSE to paver package command

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -126,6 +126,7 @@ def package(options):
         if not hasattr(options.package, "tests"):
             options.plugin.excludes.extend(options.plugin.tests)
         make_zip(f, options)
+        f.write("LICENSE", os.path.join(options.plugin.name, "LICENSE"))
 
 
 def make_zip(zipFile, options):


### PR DESCRIPTION
### What I Changed

Add LICENSE to the packaging of the plugin in `ee_plugin.zip`. Opted to keep the license at the top level of the repository for visibility, and add a separate write command of the license to the packaged zip.

```
tree "ee_plugin 2" -L 1
ee_plugin 2
├── LICENSE
├── Map.py
├── __init__.py
├── config.py
├── contrib
├── ee_auth.py
├── ee_plugin.py
├── extlibs
├── extlibs.bkp
├── extlibs_2
├── i18n
├── icons
├── logging.py
├── metadata.txt
├── processing
├── provider.py
├── ui
└── utils.py

9 directories, 10 files
```

### How to test it

- See `qgis-plugin-package.yaml` workflow from Github Actions
- Run `paver package` locally
