### PR TITLE
Improved Color Picking in Add EE Image/ Add Image Collection

### DIFF
--- a/ee_plugin/contrib/palettes.py
+++ b/ee_plugin/contrib/palettes.py
@@ -8,6 +8,9 @@
 # * 2018-08-01: Fedor Baart (f.baart@gmail.com) - added cmocean
 # * 2019-01-18: Justin Braaten (jstnbraaten@gmail.com) - added niccoli, matplotlib, kovesi, misc
 
+from typing import List
+
+
 cmocean = {
     "Thermal": {
         7: ["042333", "2c3395", "744992", "b15f82", "eb7958", "fbb43d", "e8fa5b"]
@@ -3746,27 +3749,40 @@ crameri = {
 }
 
 
-def palette_choices():
+def palette_choices() -> List[str]:
     """
     Returns a list of available palettes and their respective number of colors.
     """
 
     choices = []
-    for palette_name, palette_data in matplotlib.items():
-        choices.append([palette_name, list(palette_data.keys())])
-    for palette_name, palette_data in cb.items():
-        choices.append([palette_name, list(palette_data.keys())])
+    for palette_name in matplotlib.keys():
+        choices.append(palette_name)
+    for palette_name in cb.keys():
+        choices.append(palette_name)
     return choices
 
 
-def palette_colors(palette_name):
+def palette_colors(palette_name, num_colors):
     """
     Returns the colors of a specified palette.
     """
 
     if palette_name in matplotlib:
-        return matplotlib[palette_name][7]
+        return matplotlib[palette_name][num_colors]
     elif palette_name in cb:
-        return [f"#{x.capitalize()}" for x in cb[palette_name][7]]
+        return [f"#{x}" for x in cb[palette_name][num_colors]]
+    else:
+        raise ValueError(f"Palette '{palette_name}' not found.")
+
+
+def num_colors(palette_name) -> List[int]:
+    """
+    Returns the number of colors supported by a specified palette.
+    """
+
+    if palette_name in matplotlib:
+        return list(matplotlib[palette_name].keys())
+    elif palette_name in cb:
+        return list(cb[palette_name].keys())
     else:
         raise ValueError(f"Palette '{palette_name}' not found.")

--- a/ee_plugin/contrib/palettes.py
+++ b/ee_plugin/contrib/palettes.py
@@ -3775,14 +3775,17 @@ def palette_colors(palette_name, num_colors):
         raise ValueError(f"Palette '{palette_name}' not found.")
 
 
-def num_colors(palette_name) -> List[int]:
+def num_colors(palette_name) -> List[str]:
     """
     Returns the number of colors supported by a specified palette.
     """
 
+    res = []
     if palette_name in matplotlib:
-        return list(matplotlib[palette_name].keys())
+        res = list(matplotlib[palette_name].keys())
     elif palette_name in cb:
-        return list(cb[palette_name].keys())
+        res = list(cb[palette_name].keys())
     else:
         raise ValueError(f"Palette '{palette_name}' not found.")
+
+    return [str(x) for x in res]

--- a/ee_plugin/contrib/palettes.py
+++ b/ee_plugin/contrib/palettes.py
@@ -3744,3 +3744,29 @@ crameri = {
         ],
     },
 }
+
+
+def palette_choices():
+    """
+    Returns a list of available palettes and their respective number of colors.
+    """
+
+    choices = []
+    for palette_name, palette_data in matplotlib.items():
+        choices.append([palette_name, list(palette_data.keys())])
+    for palette_name, palette_data in cb.items():
+        choices.append([palette_name, list(palette_data.keys())])
+    return choices
+
+
+def palette_colors(palette_name):
+    """
+    Returns the colors of a specified palette.
+    """
+
+    if palette_name in matplotlib:
+        return matplotlib[palette_name][7]
+    elif palette_name in cb:
+        return [f"#{x.capitalize()}" for x in cb[palette_name][7]]
+    else:
+        raise ValueError(f"Palette '{palette_name}' not found.")

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -298,6 +298,12 @@ class VisualizationParamsWidget(QWidget):
         self.color_palette_picker = QComboBox(self)
         self.color_palette_picker.addItems(palettes.palette_choices())
         self.color_palette_picker.currentTextChanged.connect(self.update_palette)
+        self.color_palette_picker.setCurrentText("viridis")
+        self.color_palette_picker.view().setVerticalScrollBarPolicy(
+            QtCore.Qt.ScrollBarAsNeeded
+        )
+        self.color_palette_picker.setStyleSheet("QComboBox {combobox-popup: 0;}")
+        self.color_palette_picker.setMaxVisibleItems(30)
 
         # Add a separator for different palettes
         matplotlib_index = len(palettes.matplotlib)
@@ -315,7 +321,9 @@ class VisualizationParamsWidget(QWidget):
         )
 
         self.num_color_choices = QComboBox(self)
-        self.num_color_choices.addItem("7")
+        self.num_color_choices.addItems(
+            palettes.num_colors(self.color_palette_picker.currentText())
+        )
         self.num_color_choices.currentTextChanged.connect(self.update_num_colors)
 
         self.color_palette = palettes.palette_colors(
@@ -371,7 +379,7 @@ class VisualizationParamsWidget(QWidget):
     def update_palette(self):
         selected_palette = self.color_palette_picker.currentText()
         self.num_color_choices.clear()
-        choices = [str(x) for x in palettes.num_colors(selected_palette)]
+        choices = palettes.num_colors(selected_palette)
         self.num_color_choices.addItems(choices)
         self.num_color_choices.setCurrentText(median(choices))
 

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -296,6 +296,9 @@ class VisualizationParamsWidget(QWidget):
 
         # Color palette
         self.color_palette_picker = QComboBox(self)
+        self.num_color_choices = QComboBox(self)
+        self.palette_display = QHBoxLayout()
+
         self.color_palette_picker.addItems(palettes.palette_choices())
         self.color_palette_picker.currentTextChanged.connect(self.update_palette)
         self.color_palette_picker.setCurrentText("viridis")
@@ -320,7 +323,6 @@ class VisualizationParamsWidget(QWidget):
             matplotlib_index + num_multi_hue + num_single_hue + num_diverging
         )
 
-        self.num_color_choices = QComboBox(self)
         self.num_color_choices.addItems(
             palettes.num_colors(self.color_palette_picker.currentText())
         )
@@ -331,7 +333,6 @@ class VisualizationParamsWidget(QWidget):
             int(self.num_color_choices.currentText()),
         )
 
-        self.palette_display = QHBoxLayout()
         palette_widget = QWidget()
         palette_widget.setLayout(self.palette_display)
         self.layout.addRow(QLabel("Color Palette"), self.color_palette_picker)

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -298,6 +298,21 @@ class VisualizationParamsWidget(QWidget):
         self.color_palette_picker = QComboBox(self)
         self.color_palette_picker.addItems([x[0] for x in self.color_choices])
         self.color_palette_picker.currentTextChanged.connect(self.update_palette)
+
+        # Add a separator for different palettes
+        matplotlib_index = len(palettes.matplotlib)
+        num_multi_hue = 13
+        num_single_hue = 7
+        num_diverging = 10
+
+        self.color_palette_picker.insertSeparator(matplotlib_index)
+        self.color_palette_picker.insertSeparator(matplotlib_index + num_multi_hue)
+        self.color_palette_picker.insertSeparator(
+            matplotlib_index + num_multi_hue + num_single_hue
+        )
+        self.color_palette_picker.insertSeparator(
+            matplotlib_index + num_multi_hue + num_single_hue + num_diverging
+        )
         self.color_palette = palettes.palette_colors(
             self.color_palette_picker.currentText()
         )


### PR DESCRIPTION
This pull request improves the UI when adding an image or an image collection to the map using the plugin UI, making it easier and faster to add images. Resolves #274.

# Background and Motivation

The previous color picking UI was simple and easy to understand, but selecting multiple colors was slow, picking good colors relied on user knowledge about good color choices, and adding additional colors inbetween previously added colors was not possible. My changes simplify this UI, making it easier and faster to pick colormaps.

# My changes

I removed the color picking button, and added a list of palette choices, along with an option to change the number of colors used. Here is what the new UI looks like:

<img width="923" alt="image" src="https://github.com/user-attachments/assets/35fdbbeb-b142-447a-84e6-5641fc45167a" />

There are a number of available color palettes to choose from, which I've grouped together based on their function (i.e all diverging go together, all qualitative go together, and so on. 

<img width="883" alt="image" src="https://github.com/user-attachments/assets/6df5f690-c5dd-44c0-bac8-fa714a948199" />

# Limitations

Although this change makes the UI easier to use and makes it faster to select colors, it does limit the user just to the choices presented in the UI. I think that this is an okay compromise, as the user can write a script to have full control over the behaviour when needed.