### PR TITLE
Better color picking

### DIFF
--- a/ee_plugin/contrib/palettes.py
+++ b/ee_plugin/contrib/palettes.py
@@ -8,6 +8,9 @@
 # * 2018-08-01: Fedor Baart (f.baart@gmail.com) - added cmocean
 # * 2019-01-18: Justin Braaten (jstnbraaten@gmail.com) - added niccoli, matplotlib, kovesi, misc
 
+from typing import List
+
+
 cmocean = {
     "Thermal": {
         7: ["042333", "2c3395", "744992", "b15f82", "eb7958", "fbb43d", "e8fa5b"]
@@ -3746,27 +3749,40 @@ crameri = {
 }
 
 
-def palette_choices():
+def palette_choices() -> List[str]:
     """
     Returns a list of available palettes and their respective number of colors.
     """
 
     choices = []
-    for palette_name, palette_data in matplotlib.items():
-        choices.append([palette_name, list(palette_data.keys())])
-    for palette_name, palette_data in cb.items():
-        choices.append([palette_name, list(palette_data.keys())])
+    for palette_name in matplotlib.keys():
+        choices.append(palette_name)
+    for palette_name in cb.keys():
+        choices.append(palette_name)
     return choices
 
 
-def palette_colors(palette_name):
+def palette_colors(palette_name, num_colors):
     """
     Returns the colors of a specified palette.
     """
 
     if palette_name in matplotlib:
-        return matplotlib[palette_name][7]
+        return matplotlib[palette_name][num_colors]
     elif palette_name in cb:
-        return [f"#{x.capitalize()}" for x in cb[palette_name][7]]
+        return [f"#{x}" for x in cb[palette_name][num_colors]]
+    else:
+        raise ValueError(f"Palette '{palette_name}' not found.")
+
+
+def num_colors(palette_name) -> List[int]:
+    """
+    Returns the number of colors supported by a specified palette.
+    """
+
+    if palette_name in matplotlib:
+        return list(matplotlib[palette_name].keys())
+    elif palette_name in cb:
+        return list(cb[palette_name].keys())
     else:
         raise ValueError(f"Palette '{palette_name}' not found.")

--- a/ee_plugin/contrib/palettes.py
+++ b/ee_plugin/contrib/palettes.py
@@ -8,8 +8,6 @@
 # * 2018-08-01: Fedor Baart (f.baart@gmail.com) - added cmocean
 # * 2019-01-18: Justin Braaten (jstnbraaten@gmail.com) - added niccoli, matplotlib, kovesi, misc
 
-from typing import List
-
 
 cmocean = {
     "Thermal": {
@@ -3747,45 +3745,3 @@ crameri = {
         ],
     },
 }
-
-
-def palette_choices() -> List[str]:
-    """
-    Returns a list of available palettes and their respective number of colors.
-    """
-
-    choices = []
-    for palette_name in matplotlib.keys():
-        choices.append(palette_name)
-    for palette_name in cb.keys():
-        choices.append(palette_name)
-    return choices
-
-
-def palette_colors(palette_name, num_colors):
-    """
-    Returns the colors of a specified palette.
-    """
-
-    if palette_name in matplotlib:
-        return matplotlib[palette_name][num_colors]
-    elif palette_name in cb:
-        return [f"#{x}" for x in cb[palette_name][num_colors]]
-    else:
-        raise ValueError(f"Palette '{palette_name}' not found.")
-
-
-def num_colors(palette_name) -> List[str]:
-    """
-    Returns the number of colors supported by a specified palette.
-    """
-
-    res = []
-    if palette_name in matplotlib:
-        res = list(matplotlib[palette_name].keys())
-    elif palette_name in cb:
-        res = list(cb[palette_name].keys())
-    else:
-        raise ValueError(f"Palette '{palette_name}' not found.")
-
-    return [str(x) for x in res]

--- a/ee_plugin/contrib/palettes.py
+++ b/ee_plugin/contrib/palettes.py
@@ -3775,14 +3775,17 @@ def palette_colors(palette_name, num_colors):
         raise ValueError(f"Palette '{palette_name}' not found.")
 
 
-def num_colors(palette_name) -> List[int]:
+def num_colors(palette_name) -> List[str]:
     """
     Returns the number of colors supported by a specified palette.
     """
 
+    res = []
     if palette_name in matplotlib:
-        return list(matplotlib[palette_name].keys())
+        res = list(matplotlib[palette_name].keys())
     elif palette_name in cb:
-        return list(cb[palette_name].keys())
+        res = list(cb[palette_name].keys())
     else:
         raise ValueError(f"Palette '{palette_name}' not found.")
+
+    return [str(x) for x in res]

--- a/ee_plugin/contrib/palettes.py
+++ b/ee_plugin/contrib/palettes.py
@@ -3744,3 +3744,29 @@ crameri = {
         ],
     },
 }
+
+
+def palette_choices():
+    """
+    Returns a list of available palettes and their respective number of colors.
+    """
+
+    choices = []
+    for palette_name, palette_data in matplotlib.items():
+        choices.append([palette_name, list(palette_data.keys())])
+    for palette_name, palette_data in cb.items():
+        choices.append([palette_name, list(palette_data.keys())])
+    return choices
+
+
+def palette_colors(palette_name):
+    """
+    Returns the colors of a specified palette.
+    """
+
+    if palette_name in matplotlib:
+        return matplotlib[palette_name][7]
+    elif palette_name in cb:
+        return [f"#{x.capitalize()}" for x in cb[palette_name][7]]
+    else:
+        raise ValueError(f"Palette '{palette_name}' not found.")

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -37,6 +37,7 @@ from ..utils import (
     get_available_bands,
     filter_functions,
 )
+from ..ui.utils import serialize_color_ramp
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +263,8 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
                     selected_bands.append(band_dropdown.currentText())
 
             viz_params = self.viz_widget.get_viz_params()
-
+            serialized = serialize_color_ramp(viz_params)
+            viz_params["palette"] = serialized["palette"]
             extent = self.extent_group.outputExtent()
             params = {
                 "image_collection_id": self.image_collection_id.text(),

--- a/ee_plugin/ui/utils.py
+++ b/ee_plugin/ui/utils.py
@@ -5,6 +5,15 @@ from qgis.PyQt.QtWidgets import QDialog
 from .widget_parsers import get_dialog_values
 
 
+from qgis.core import (
+    QgsGradientColorRamp,
+    QgsColorBrewerColorRamp,
+    QgsLimitedRandomColorRamp,
+    QgsPresetSchemeColorRamp,
+    QgsCptCityColorRamp,
+)
+
+
 def call_func_with_values(func: Callable, dialog: QDialog):
     """
     Call a function with values from a dialog. Prior to the call, the function signature
@@ -16,3 +25,24 @@ def call_func_with_values(func: Callable, dialog: QDialog):
     dialog_values = get_dialog_values(dialog)
     kwargs = {k: v for k, v in dialog_values.items() if k in func_kwargs}
     return func(**kwargs)
+
+
+def serialize_color_ramp(viz_params):
+    result = {}
+    k = "palette"
+    if "palette" in viz_params:
+        v = viz_params[k]
+        if isinstance(v, QgsGradientColorRamp):
+            result[k] = [stop.color.name() for stop in v.stops()]
+        elif isinstance(v, QgsColorBrewerColorRamp):
+            result[k] = [v.color(i).name() for i in range(v.count())]
+        elif isinstance(v, QgsLimitedRandomColorRamp):
+            count = v.count()
+            result[k] = [v.color(i).name() for i in range(count)]
+        elif isinstance(v, QgsPresetSchemeColorRamp):
+            result[k] = [c.name() for c in v.colors()]
+        elif isinstance(v, QgsCptCityColorRamp):
+            result[k] = [c.name() for c in v.colors()]
+        else:
+            result[k] = []
+    return result

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -298,6 +298,12 @@ class VisualizationParamsWidget(QWidget):
         self.color_palette_picker = QComboBox(self)
         self.color_palette_picker.addItems(palettes.palette_choices())
         self.color_palette_picker.currentTextChanged.connect(self.update_palette)
+        self.color_palette_picker.setCurrentText("viridis")
+        self.color_palette_picker.view().setVerticalScrollBarPolicy(
+            QtCore.Qt.ScrollBarAsNeeded
+        )
+        self.color_palette_picker.setStyleSheet("QComboBox {combobox-popup: 0;}")
+        self.color_palette_picker.setMaxVisibleItems(30)
 
         # Add a separator for different palettes
         matplotlib_index = len(palettes.matplotlib)
@@ -315,7 +321,9 @@ class VisualizationParamsWidget(QWidget):
         )
 
         self.num_color_choices = QComboBox(self)
-        self.num_color_choices.addItem("7")
+        self.num_color_choices.addItems(
+            palettes.num_colors(self.color_palette_picker.currentText())
+        )
         self.num_color_choices.currentTextChanged.connect(self.update_num_colors)
 
         self.color_palette = palettes.palette_colors(
@@ -371,7 +379,7 @@ class VisualizationParamsWidget(QWidget):
     def update_palette(self):
         selected_palette = self.color_palette_picker.currentText()
         self.num_color_choices.clear()
-        choices = [str(x) for x in palettes.num_colors(selected_palette)]
+        choices = palettes.num_colors(selected_palette)
         self.num_color_choices.addItems(choices)
         self.num_color_choices.setCurrentText(median(choices))
 

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -296,6 +296,9 @@ class VisualizationParamsWidget(QWidget):
 
         # Color palette
         self.color_palette_picker = QComboBox(self)
+        self.num_color_choices = QComboBox(self)
+        self.palette_display = QHBoxLayout()
+
         self.color_palette_picker.addItems(palettes.palette_choices())
         self.color_palette_picker.currentTextChanged.connect(self.update_palette)
         self.color_palette_picker.setCurrentText("viridis")
@@ -320,7 +323,6 @@ class VisualizationParamsWidget(QWidget):
             matplotlib_index + num_multi_hue + num_single_hue + num_diverging
         )
 
-        self.num_color_choices = QComboBox(self)
         self.num_color_choices.addItems(
             palettes.num_colors(self.color_palette_picker.currentText())
         )
@@ -331,7 +333,6 @@ class VisualizationParamsWidget(QWidget):
             int(self.num_color_choices.currentText()),
         )
 
-        self.palette_display = QHBoxLayout()
         palette_widget = QWidget()
         palette_widget.setLayout(self.palette_display)
         self.layout.addRow(QLabel("Color Palette"), self.color_palette_picker)

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -298,6 +298,21 @@ class VisualizationParamsWidget(QWidget):
         self.color_palette_picker = QComboBox(self)
         self.color_palette_picker.addItems([x[0] for x in self.color_choices])
         self.color_palette_picker.currentTextChanged.connect(self.update_palette)
+
+        # Add a separator for different palettes
+        matplotlib_index = len(palettes.matplotlib)
+        num_multi_hue = 13
+        num_single_hue = 7
+        num_diverging = 10
+
+        self.color_palette_picker.insertSeparator(matplotlib_index)
+        self.color_palette_picker.insertSeparator(matplotlib_index + num_multi_hue)
+        self.color_palette_picker.insertSeparator(
+            matplotlib_index + num_multi_hue + num_single_hue
+        )
+        self.color_palette_picker.insertSeparator(
+            matplotlib_index + num_multi_hue + num_single_hue + num_diverging
+        )
         self.color_palette = palettes.palette_colors(
             self.color_palette_picker.currentText()
         )

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -334,8 +334,6 @@ class VisualizationParamsWidget(QWidget):
             params["gamma"] = self.viz_gamma.value()
         return params
 
-    # Removed update_palette, update_num_colors, add_colors_from_palette methods
-
 
 class FilterWidget(gui.QgsCollapsibleGroupBox):
     def __init__(self, title="Filter by Properties", property_list=None, parent=None):


### PR DESCRIPTION
### What I Changed

This PR enhances the “Add EE Image” feature by improving the color selection mechanism, allowing users to apply custom color palettes to Earth Engine images within QGIS more intuitively. The update addresses [Issue #274](https://github.com/gee-community/qgis-earthengine-plugin/issues/274), which highlighted the need for a more user-friendly color selection process.

- Implemented a new color picker dialog that provides a more intuitive interface for selecting color palettes.
- Updated the “Add EE Image” and “Add Image Collection” dialogs to integrate the improved color picker.
- Refactored related code to support the enhanced color selection functionality.

### How to test it
1. Open QGIS and activate the Earth Engine plugin.
2. Use the “Add EE Image” feature to load an Earth Engine image.
3. In the dialog, utilize the new color picker to select a custom color palette.
4. Confirm that the selected palette is applied correctly to the loaded image.
5. Repeat 2-4 for Image Collection

### Demo

We can select predefined color ramps and have the ramp displayed:
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/98b2f6c7-4229-452a-8373-5c39067a8496" />

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/763540d0-57e6-40a9-81fd-b8c096ef5d0a" />

We can also create a new color ramp of a few different types: 
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/942c5f13-e98e-4684-ae31-34ba7b2fdd3e" />

The layout to create the color ramp will change based on the type, but we have very fine control over it:
Color presets:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/ad66ec62-5269-457e-b4a3-02c691581844" />

Color Brewer:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/2e80dc7b-43be-476b-9410-c8074e6b4bf0" />

cpt-city:
<img width="799" alt="image" src="https://github.com/user-attachments/assets/0eaf71ec-7f23-4ed9-aead-fcb612407c6a" />

Gradient:
<img width="869" alt="image" src="https://github.com/user-attachments/assets/7d12ba9e-e435-498f-b29e-539eb0ca4770" />

### Other Notes

Thanks to @ebiederstadt for starting the implementation here! 🙇 

Closes #274 

