### PR TITLE
Fixes to Image Collection Algorithm

### DIFF
--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -14,7 +14,7 @@ from qgis.core import (
     QgsProcessingParameterExtent,
     QgsRectangle,
 )
-from qgis.PyQt.QtCore import QTimer
+from qgis.PyQt.QtCore import QTimer, QDate
 from qgis.PyQt.QtWidgets import (
     QVBoxLayout,
     QFormLayout,
@@ -187,12 +187,14 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
 
         # --- Filter by Dates ---
         date_group = gui.QgsCollapsibleGroupBox(_("Filter by Dates"))
-        date_group.setCollapsed(True)
+        date_group.setCollapsed(False)
         date_layout = QFormLayout()
         self.start_date = gui.QgsDateEdit(objectName="start_date")
         self.start_date.setToolTip(_("Start date for filtering"))
+        self.start_date.setDate(QDate(1900, 1, 1))  # All-inclusive start date
         self.end_date = gui.QgsDateEdit(objectName="end_date")
         self.end_date.setToolTip(_("End date for filtering"))
+        self.end_date.setDate(QDate.currentDate())  # Default to today
 
         date_layout.addRow(_("Start"), self.start_date)
         date_layout.addRow(_("End"), self.end_date)

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -201,10 +201,10 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
         date_group.setLayout(date_layout)
         layout.addWidget(date_group)
 
-        # --- Filter by Coordinates ---
+        # --- Filter by Extent ---
         self.extent_group = gui.QgsExtentGroupBox(
             objectName="extent",
-            title=_("Filter by Coordinates"),
+            title=_("Filter by Extent (Bounds)"),
             collapsed=True,
         )
         self.extent_group.setMapCanvas(Map.get_iface().mapCanvas())

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -267,7 +267,8 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
 
             viz_params = self.viz_widget.get_viz_params()
             serialized = serialize_color_ramp(viz_params)
-            viz_params["palette"] = serialized["palette"]
+            if serialized.get("palette"):
+                viz_params["palette"] = serialized["palette"]
             extent = self.extent_group.outputExtent()
             params = {
                 "image_collection_id": self.image_collection_id.text(),

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -191,10 +191,11 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
         date_layout = QFormLayout()
         self.start_date = gui.QgsDateEdit(objectName="start_date")
         self.start_date.setToolTip(_("Start date for filtering"))
-        self.start_date.setDate(QDate(1900, 1, 1))  # All-inclusive start date
+        # keep empty dates
+        self.start_date.setDate(QDate())
         self.end_date = gui.QgsDateEdit(objectName="end_date")
         self.end_date.setToolTip(_("End date for filtering"))
-        self.end_date.setDate(QDate.currentDate())  # Default to today
+        self.end_date.setDate(QDate())  # default to today
 
         date_layout.addRow(_("Start"), self.start_date)
         date_layout.addRow(_("End"), self.end_date)
@@ -271,8 +272,12 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
             params = {
                 "image_collection_id": self.image_collection_id.text(),
                 "filters": filters_str,
-                "start_date": self.start_date.dateTime(),
-                "end_date": self.end_date.dateTime(),
+                "start_date": self.start_date.dateTime()
+                if self.start_date.dateTime()
+                else None,
+                "end_date": self.end_date.dateTime()
+                if self.end_date.dateTime()
+                else None,
                 "extent": (
                     f"{extent.xMinimum()},{extent.xMaximum()},{extent.yMinimum()},{extent.yMaximum()}"
                     if not extent.isEmpty()

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -503,6 +503,9 @@ class AddImageCollectionAlgorithm(QgsProcessingAlgorithm):
                 raise ValueError("Percentile value must be between 0 and 100.")
             ic = ic.reduce(ee.Reducer.percentile([percentile_value]))
         elif compositing_name == "First":
+            logger.warning(
+                "Using 'First' compositing method, which returns the first image in the collection. This method is only practical for collections with a single image."
+            )
             ic = ic.first()
         elif compositing_name == "Mosaic":
             ic = ic.mosaic()

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -76,7 +76,7 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
 
         self.compositing_method = QComboBox(objectName="compositing_method")
         self.compositing_method.addItems(
-            ["Mosaic", "Mean", "Max", "Min", "Median", "Percentile"]
+            ["Mosaic", "Mean", "Max", "Min", "Median", "Percentile", "First"]
         )
         self.compositing_method.setToolTip(_("Select a compositing method."))
         compositing_layout.addRow(_("Compositing Method"), self.compositing_method)
@@ -362,7 +362,15 @@ class AddImageCollectionAlgorithm(QgsProcessingAlgorithm):
             QgsProcessingParameterEnum(
                 "compositing_method",
                 "Compositing Method",
-                options=["Mosaic", "Mean", "Max", "Min", "Median", "Percentile"],
+                options=[
+                    "Mosaic",
+                    "Mean",
+                    "Max",
+                    "Min",
+                    "Median",
+                    "Percentile",
+                    "First",
+                ],
                 optional=False,
                 defaultValue=0,
             )
@@ -474,6 +482,7 @@ class AddImageCollectionAlgorithm(QgsProcessingAlgorithm):
             "Min": ic.min(),
             "Median": ic.median(),
             "Percentile": ic.reduce(ee.Reducer.percentile([percentile_value])),
+            "First": ic.first(),
         }
 
         ic = compositing_dict.get(compositing_method, ic.mosaic())
@@ -498,7 +507,15 @@ class AddImageCollectionAlgorithm(QgsProcessingAlgorithm):
             )
 
         # compositing method is an index
-        compositing_options = ["Mosaic", "Mean", "Max", "Min", "Median", "Percentile"]
+        compositing_options = [
+            "Mosaic",
+            "Mean",
+            "Max",
+            "Min",
+            "Median",
+            "Percentile",
+            "First",
+        ]
         compositing_name = compositing_options[compositing_method]
         if compositing_name == "Percentile":
             name = f"IC: {image_collection_id} ({compositing_name} {percentile_value}%)"

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -509,7 +509,7 @@ class AddImageCollectionAlgorithm(QgsProcessingAlgorithm):
             ic = ic.reduce(ee.Reducer.percentile([percentile_value]))
         elif compositing_name == "First":
             logger.warning(
-                "Using 'First' compositing method, which returns the first image in the collection. This method is only practical for collections with a single image."
+                "Using 'First' compositing method, which returns the first image in the collection."
             )
             ic = ic.first()
         elif compositing_name == "Mosaic":

--- a/ee_plugin/ui/utils.py
+++ b/ee_plugin/ui/utils.py
@@ -37,12 +37,13 @@ def serialize_color_ramp(viz_params):
         elif isinstance(v, QgsColorBrewerColorRamp):
             result[k] = [v.color(i).name() for i in range(v.count())]
         elif isinstance(v, QgsLimitedRandomColorRamp):
-            count = v.count()
-            result[k] = [v.color(i).name() for i in range(count)]
+            result[k] = [v.color(i).name() for i in range(v.count())]
         elif isinstance(v, QgsPresetSchemeColorRamp):
             result[k] = [c.name() for c in v.colors()]
         elif isinstance(v, QgsCptCityColorRamp):
             result[k] = [c.name() for c in v.colors()]
         else:
             result[k] = []
+    else:
+        result[k] = []
     return result

--- a/ee_plugin/ui/widgets.py
+++ b/ee_plugin/ui/widgets.py
@@ -296,12 +296,19 @@ class VisualizationParamsWidget(QWidget):
         self.layout.addRow(QLabel("Color Ramp"), self.color_ramp)
 
         # min, max, gamma, opacity
-        self.viz_min = self._make_spinbox(-1e6, 1e6, "Min", num_decimals=4)
-        self.viz_max = self._make_spinbox(
-            -1e6, 1e6, "Max", default=10000, num_decimals=4
+        self.viz_min = self._make_spinbox(
+            -1e6, 1e6, "Min", default=None, num_decimals=4
         )
-        self.viz_gamma = self._make_spinbox(1.00, 10.0, "Gamma")
-        self.viz_opacity = self._make_spinbox(0.01, 1.0, "Opacity", default=1.0)
+        self.viz_max = self._make_spinbox(
+            -1e6, 1e6, "Max", default=None, num_decimals=4
+        )
+        self.viz_gamma = self._make_spinbox(
+            1.00,
+            10.0,
+            "Gamma",
+            default=None,
+        )
+        self.viz_opacity = self._make_spinbox(0.01, 1.0, "Opacity", default=None)
 
         self.setLayout(self.layout)
 
@@ -310,8 +317,12 @@ class VisualizationParamsWidget(QWidget):
         spin.setRange(min_val, max_val)
         spin.setDecimals(num_decimals)
         spin.setSingleStep(10**-num_decimals)
+        spin.setSpecialValueText("")  # allows visual blank
+        spin.clear()
+
         if default is not None:
             spin.setValue(default)
+
         self.layout.addRow(QLabel(label), spin)
         setattr(self, f"viz_{label.lower()}", spin)
         return spin
@@ -320,18 +331,24 @@ class VisualizationParamsWidget(QWidget):
         bands = [
             combo.currentText() for combo in self.band_selection if combo.currentText()
         ]
-        params = {
-            "bands": bands,
-            "min": self.viz_min.value(),
-            "max": self.viz_max.value(),
-            "opacity": self.viz_opacity.value(),
-        }
-        # Use color ramp if selected
-        # ee uses palette to map colors
-        if self.color_ramp.colorRamp():
-            params["palette"] = self.color_ramp.colorRamp().clone()
-        else:
+        params = {}
+
+        if bands:
+            params["bands"] = bands
+
+        if self.viz_min.lineEdit().text().strip():
+            params["min"] = self.viz_min.value()
+        if self.viz_max.lineEdit().text().strip():
+            params["max"] = self.viz_max.value()
+        if self.viz_gamma.lineEdit().text().strip():
             params["gamma"] = self.viz_gamma.value()
+        if self.viz_opacity.lineEdit().text().strip():
+            params["opacity"] = self.viz_opacity.value()
+
+        ramp = self.color_ramp.colorRamp()
+        if ramp and ramp.count() > 0:
+            params["palette"] = ramp
+
         return params
 
 


### PR DESCRIPTION
### What I Changed

- Change prepopulated visualization parameters to empty
- Add missing palette key when no palette is provided
- Add the first option to compositing (also warns user that it should only be for image collection with a single image cc: @gena @spatialthoughts)

### How to test it

- Run the add image collection with the Sentinel-2 Harmonized dataset: https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_S2_SR_HARMONIZED
- Run the add image collection using the first compositing method with the ESA world cover dataset: https://developers.google.com/earth-engine/datasets/catalog/ESA_WorldCover_v200

### Other Notes

- Closes #288 
- Closes #304 
- Closes #305 
- Closes #306 
- Closes #302 
- Closes #296 