### PR TITLE
chore: release please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "changelog-path": "CHANGELOG.md",
+      "include-v-in-tag": true,
+      "bump-minor-pre-major": true,
+      "extra-files": ["ee_plugin/metadata.txt"],
+      "version-file": "ee_plugin/metadata.txt"
+    }
+  }
+}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,15 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses:  ytanikin/pr-conventional-commits@1.4.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,54 @@
-name: Release QGIS Plugin
+name: 📦 Release
 
 on:
   push:
-    tags:
-      - 'v*.*.*'  # Trigger only on version tags like v1.2.3
+    branches:
+      - main
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  release:
+  release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: googleapis/release-please-action@v4
+        id: rp
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/release-please-config.json
+
+  package-and-publish:
+    if: github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')
+    needs: release-please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
 
-      - name: Get tag version
+      - name: Extract version
         run: |
-          raw="${GITHUB_REF#refs/tags/}"
-          VERSION="${raw#v}"
+          VERSION="${{ github.event.release.tag_name#v }}"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
-      - name: Create release (if it doesn't exist)
-        run: gh release create v${{ env.VERSION }} --title "v${{ env.VERSION }}" --generate-notes || echo "Release already exists"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish plugin via QGIS‑Plugin‑CI
+      - name: Install deps
         run: |
           pip install qgis-plugin-ci
           pip install -r requirements.txt -t ee_plugin/extlibs
-          find ee_plugin/extlibs -type d -name __pycache__ -exec rm -rf {} +
-          find ee_plugin/extlibs -type d -name '*.dist-info' -exec rm -rf {} +
+
+      - name: Package & Release plugin
+        run: |
           qgis-plugin-ci release "$VERSION" \
-            --release-tag "v$VERSION" \
+            --release-tag "${{ github.event.release.tag_name }}" \
             --github-token "${{ secrets.GITHUB_TOKEN }}" \
             --osgeo-username "${{ secrets.OSGEO_USER }}" \
             --osgeo-password "${{ secrets.OSGEO_PASS }}" \


### PR DESCRIPTION
### What changed
- Added `.github/release-please-config.json` to enable automatic version bumping (metadata.txt) and changelog updates via the Release Please GitHub Action.
- Introduced `.github/workflows/release.yml`, which now:
   * Uses `release-please` job on push to main to generate/update a Release PR.
   * Uses `package-and-publish` job triggered by GitHub Release to run `qgis-plugin-ci`, build the plugin ZIP, attach it to the release, and publish to QGIS plugin repo.

### How to test
1. Push a conventional-commit (e.g., `feat: add example`) to `main`.
2. Verify that a Release PR is automatically opened and updated with version bumps and changelog changes.
3. Merge the Release PR.
4. Confirm a new GitHub Release appears with the correct version tag and attached plugin ZIP.
5. Verify plugin is published via the QGIS plugin manager.

### Other notes
- Closes #338 
- This setup retains human review via Release PR while fully automating release and packaging steps.