### PR TITLE
requirements.txt: Update minimum ee client ver to 1.5.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ratelim
-earthengine-api>=0.1.335
+earthengine-api>=1.5.12
 six>=1.13
 httplib2
 requests>2.4


### PR DESCRIPTION
This change is needed because of this change:

google/earthengine-api@27d6d9e

> Add https://www.googleapis.com/auth/drive scope to the default OAuth scopes

See similar change https://github.com/gee-community/geemap/commit/fd28ab4556474c1d975b2c70d6bbf11eaa46d16d