### PR TITLE
Update earthengineapi version, demove PyQt5 dependency, pin pyOpenSSL

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest==7.4.3 # pytest-qgis does not support pytest>=8
 pytest-cov
 pytest-qgis==2.1.0
 pre-commit
-pyqt5
 future
 rasterio
 qgis-plugin-ci
+pyOpenSSL<24.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ratelim
-earthengine-api>=0.1.335
+earthengine-api>=1.5.12
 six>=1.13
 httplib2
 requests>2.4


### PR DESCRIPTION
### What I am Changing

- Updated EarthEngineAPI version based on #350 
- Updated other dependencies (remove conflicting `PyQt5` version, pin `pyOpenSSL` version)

### How to test it

- See CI
- Reauthenticate and run some examples

### Other Notes

- Required updating our credentials secret so it has the required scope
- Updating will require users to re-sign in to have the required scope to work with version `earthengine-api>=1.5.12`



