### PR TITLE
fix: create two separate launch commands for debugger vs. testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,18 +2,27 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Python: QGIS LTR",
+      "name": "Run All Tests",
       "type": "debugpy",
       "request": "launch",
-      "program": "${workspaceFolder}/test", 
       "module": "pytest",
-      "args": [],
+      "args": ["test"],
       "console": "integratedTerminal",
       "python": "/Applications/QGIS-LTR.app/Contents/MacOS/bin/python3",
       "env": {
         "DYLD_FRAMEWORK_PATH": "/Applications/QGIS-LTR.app/Contents/Frameworks",
         "DYLD_LIBRARY_PATH": "/Applications/QGIS-LTR.app/Contents/MacOS/lib"
       }
+    },
+    {
+      "name": "Attach to QGIS Python",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      },
+      "justMyCode": false
     }
   ]
 }


### PR DESCRIPTION
### What I Changed

Create two separate launch commands for debugger vs. testing

### How to test it

- Install the plugin via symlinking (see `contributing.md`)
- Setup some breakpoints for debugging
- Test that they hit when executing an algorithm through QGIS
- Run tests via the VS code testing tab

### Other notes

Closes #351 