### PR TITLE
fix: add QGIS plugin CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Package & Release plugin
         run: |
+          pip install qgis-plugin-ci
           qgis-plugin-ci release "$VERSION" \
             --release-tag "${{ github.event.release.tag_name }}" \
             --github-token "${{ secrets.GITHUB_TOKEN }}" \


### PR DESCRIPTION
Noticed the [publish workflow](https://github.com/gee-community/qgis-earthengine-plugin/actions/runs/16679606150) was failing because of the missing `qgis-plugin-ci` dependency. Adding it here!