### PR TITLE
fix: remove query parameters to url that break xyz tile url

### DIFF
--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -72,7 +72,7 @@ def get_layer_by_name(name: str) -> Optional[QgsMapLayer]:
 
 def get_ee_image_url(image: ee.Image) -> str:
     map_id = ee.data.getMapId({"image": image})
-    url = map_id["tile_fetcher"].url_format + "&zmax=12&minzoom=5&cache=1"
+    url = map_id["tile_fetcher"].url_format
     logger.debug(f"Generated EE image URL: {url}")
     return url
 


### PR DESCRIPTION
## What I changed

- Fixed `get_ee_image_url()` in `utils.py` to return the Earth Engine tile URL exactly as provided by `tile_fetcher.url_format`
- Removed the manual appending of query parameters (e.g., `&zmax=12&minzoom=5&cache=1`) which was corrupting the tile URL format (`{x}`, `{y}`, `{z}`) and causing API errors on Windows
- Ensured the plugin passes a clean templated tile URL to QGIS for correct rendering

## How to test it

1. Open QGIS with the Earth Engine plugin enabled
2. Run this code snippet in the Python console (remove `project="my-project"` if present):
   ```python
   import ee
   from ee_plugin import Map
   ee.Authenticate()
   ee.Initialize()

   image = (
       ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")
       .filterBounds(Map.getCenter())
       .filterDate('2025-05-10', '2025-12-20')
       .first()
   )

   date = ee.Date(image.get('system:time_start')).format('YYYY-MM-dd').getInfo()
   Map.addLayer(image, {'min': 0, 'max': 5000, 'bands': ['B8', 'B11', 'B4']}, 'Image ' + date)

3. Confirm that the layer renders correctly in both:
    - Windows (where the bug was raised initially)
    - macOS (which worked previously)

## Other Notes

- resolves #364
- [hunch to be confirmed] The issue stemmed from platform-specific differences in how {x}/{y}/{z} tile templates are interpreted and forwarded to the Earth Engine API