### PR TITLE
fix: export geotiff bugs

### DIFF
--- a/test/test_export_geotiff.py
+++ b/test/test_export_geotiff.py
@@ -140,3 +140,112 @@ def test_extent_transformed_to_target_crs():
         assert ds.count == 1
 
     os.remove(out_path)
+
+
+def test_multiband_s2_export_hits_request_size_limit():
+    """
+    Reproduces #367 more deterministically by using a region around Paris.
+
+    Creates a multiband Sentinel-2 median composite over the Paris region
+    so the export hits the request/tiling limits without synthetic bands.
+    """
+    time.sleep(1)  # keep EE connection pool happy
+
+    # Paris bbox
+    roi = ee.Geometry.Rectangle([2.252, 48.815, 2.424, 48.902])
+
+    # Build a June 2021 S2 collection over ROI
+    collection = (
+        ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")
+        .filterBounds(roi)
+        .filterDate("2021-06-01", "2021-06-30")
+        .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", 20))
+    )
+
+    # Median composite with native S2 bands only
+    img = collection.median().select(collection.first().bandNames())
+
+    # Add to map so the algorithm can resolve EE_IMAGE=0 by layer index
+    Map.addLayer(img, {}, "S2_MEDIAN_HUGE")
+
+    alg = ExportGeoTIFFAlgorithm()
+    alg.initAlgorithm(config=None)
+    alg.raster_layers = ["S2_MEDIAN_HUGE"]
+
+    context = QgsProcessingContext()
+    feedback = QgsProcessingFeedback()
+
+    # Paris Web Mercator extent
+    extent_3857 = "253657.1743,268012.9419,6245507.9284,6256461.8554 [EPSG:3857]"
+
+    params = {
+        "EE_IMAGE": 0,
+        "EXTENT": extent_3857,
+        "SCALE": 10,
+        "PROJECTION": "EPSG:3857",
+        "OUTPUT": "test_s2_multiband_3857_10m.tif",
+    }
+
+    try:
+        alg.processAlgorithm(params, context=context, feedback=feedback)
+    except Exception as e:
+        msg = str(e)
+        if (
+            "Total request size" in msg
+            or "thumbnails" in msg
+            or "HttpError 400" in msg
+            or "must be less than or equal to 50331648" in msg
+            or "must be less than or equal to" in msg
+        ):
+            raise AssertionError(f"Export failed due to request size limit: {msg}")
+        else:
+            raise e
+
+
+def test_s2_first_export_paris_succeeds():
+    """Explicit check that a simple 'first' composite exports successfully over Paris."""
+    time.sleep(1)
+
+    # Paris bbox
+    roi = ee.Geometry.Rectangle([2.252, 48.815, 2.424, 48.902])
+
+    # June 2021 S2 collection
+    collection = (
+        ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")
+        .filterBounds(roi)
+        .filterDate("2021-06-01", "2021-06-30")
+        .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", 20))
+    )
+
+    # Use only the first image (lighter request graph)
+    img = ee.Image(collection.first()).select(collection.first().bandNames())
+
+    layer_name = "S2_FIRST"
+    Map.addLayer(img, {}, layer_name)
+
+    alg = ExportGeoTIFFAlgorithm()
+    alg.initAlgorithm(config=None)
+    alg.raster_layers = [layer_name]
+
+    context = QgsProcessingContext()
+    feedback = QgsProcessingFeedback()
+
+    extent_3857 = "253657.1743,268012.9419,6245507.9284,6256461.8554 [EPSG:3857]"
+    out_path = "test_s2_first_3857_10m.tif"
+
+    params = {
+        "EE_IMAGE": 0,
+        "EXTENT": extent_3857,
+        "SCALE": 10,
+        "PROJECTION": "EPSG:3857",
+        "OUTPUT": out_path,
+    }
+
+    # Should complete without hitting the 48 MiB request-size limit
+    alg.processAlgorithm(params, context=context, feedback=feedback)
+
+    assert os.path.exists(out_path) and os.path.getsize(out_path) > 0
+    with rio.open(out_path) as ds:
+        assert ds.width > 0 and ds.height > 0
+        assert ds.count >= 1
+    os.remove(out_path)


### PR DESCRIPTION
### What I changed  
- Added `test_multiband_s2_export_hits_request_size_limit` to reproduce potential request-size issues from [#367](https://github.com/gee-community/qgis-earthengine-plugin/issues/367).  
- Generated a large multiband Sentinel-2 composite over Paris to trigger large request bodies.  
- Added a data type check instead of hardcoding the number of bytes 
- Fixed destination and target CRS comparison

### How to test it
- Run the test suite:  
```bash
pytest test/test_export_geotiff.py::test_multiband_s2_export_hits_request_size_limit
```
- Try the export tool in the QGIS plugin

### Other notes
- Closes #367
- Closes #368 
- Thanks @spatialthoughts for opening the issue!

