### PR TITLE
docs: update gh action for mkdocs

### DIFF
--- a/.github/workflows/actions/setup-extlibs/action.yml
+++ b/.github/workflows/actions/setup-extlibs/action.yml
@@ -1,56 +1,13 @@
-# .github/workflows/docs.yml
-name: Build & Deploy Docs (MkDocs)
+name: Setup extlibs
+description: Install and clean up plugin dependencies
 
-on:
-  push:
-    branches: [ main ]
-  workflow_dispatch:
-
-# Required for Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-          cache: "pip"
-          cache-dependency-path: requirements-docs.txt
-
-      - name: Install docs deps
-        run: pip install -r requirements-docs.txt
-
-      - name: Build MkDocs site
-        run: mkdocs build --strict --site-dir site
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+runs:
+  using: "composite"
+  steps:
+    - name: Install plugin dependencies into extlibs
+      shell: bash
+      run: |
+        mkdir -p ee_plugin/extlibs
+        pip install -r requirements.txt -t ee_plugin/extlibs
+        find ee_plugin/extlibs -type f \( -name '*.so' -o -name '*.pyd' -o -name '*.dylib' \) -delete
+        find ee_plugin/extlibs -type d -name __pycache__ -exec rm -rf {} +

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,23 +1,56 @@
 # .github/workflows/docs.yml
-name: Publish docs via GitHub Pages
+name: Build & Deploy Docs (MkDocs)
 
 on:
   push:
     branches: [ main ]
   workflow_dispatch:
 
+# Required for Pages
 permissions:
-  contents: write # to deploy to GitHub Pages
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Deploy MkDocs to gh-pages
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONFIG_FILE: mkdocs.yml
-          REQUIREMENTS: requirements-docs.txt 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: "pip"
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install docs deps
+        run: pip install -r requirements-docs.txt
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict --site-dir site
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What I changed  
- Switched GitHub Pages deployment from the old **gh-pages branch** approach to the new **GitHub Actions workflow**.  
- Added a workflow (`.github/workflows/docs.yml`) that builds the MkDocs site and deploys it through the official Pages actions.  
- Updated repository Pages settings to use **GitHub Actions** as the source.  

## How to test it  
- Push to `main` and confirm the **Build & Deploy Docs (MkDocs)** workflow runs successfully.  
- Check the deployment under **Environments → github-pages** for the published site URL.  

## Other notes  
- Closes #380 