### PR TITLE
fix: add handling of layer references from processing models

### DIFF
--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -699,17 +699,3 @@ def get_ee_extent(
     )
 
     return ee_extent
-
-
-def get_ee_extent_from_layer(
-    layer: QgsVectorLayer, context: QgsProcessingContext
-) -> ee.Geometry:
-    """
-    Get the Earth Engine extent from a QGIS vector layer.
-    """
-    logger.debug(f"Getting EE extent from layer: {layer.name()}")
-    logger.debug(f"Layer CRS: {layer}")
-    provider = layer.dataProvider()
-    extent = provider.extent()
-    extent_crs = layer.crs()
-    return get_ee_extent(extent, extent_crs, context)


### PR DESCRIPTION
## What I Changed

Added a code path to handle layer references that come from a processing model. We initially resolve that reference to a `QgsVectorLayer` and extract the bounding box (`QgsRectangle`) from it. 

## How to test it

- Run the model referenced in #384 

## Other Notes

- closes #384
- Thanks for flagging @spatialthoughts