### PR TITLE
fix: dereferencing error on windows

### DIFF
--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -4,6 +4,7 @@ from typing import List
 
 import ee
 from qgis.core import (
+    Qgis,
     QgsProcessingAlgorithm,
     QgsProcessingParameterString,
     QgsProcessingParameterEnum,
@@ -433,6 +434,9 @@ class AddImageCollectionAlgorithm(QgsProcessingAlgorithm):
         return parsed_filters
 
     def createCustomParametersWidget(self, parent=...):
+        # Use stock Processing dialog on older QGIS where custom dialog init is fragile
+        if Qgis.QGIS_VERSION_INT < 34000:
+            return None
         return AddImageCollectionAlgorithmDialog(algorithm=self, parent=parent)
 
     def processAlgorithm(self, parameters, context, feedback):

--- a/ee_plugin/processing/custom_algorithm_dialog.py
+++ b/ee_plugin/processing/custom_algorithm_dialog.py
@@ -14,7 +14,7 @@ from qgis.core import (
     QgsTask,
     QgsApplication,
 )
-from qgis.PyQt.QtCore import Qt, QT_VERSION_STR
+from qgis.PyQt.QtCore import Qt, QT_VERSION_STR, QTimer
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtWidgets import QWidget
 from qgis import gui, processing
@@ -42,7 +42,7 @@ class BaseAlgorithmDialog(gui.QgsProcessingAlgorithmDialogBase):
             mode=gui.QgsProcessingAlgorithmDialogBase.DialogMode.Single,
         )
         self.context = self.createContext()
-        self.setAlgorithm(algorithm)
+        QTimer.singleShot(0, lambda: self.setAlgorithm(algorithm))
         self.setModal(True)
         self.setWindowTitle(title or algorithm.displayName())
 


### PR DESCRIPTION
Still a WIP, I need to test more thoroughly on a windows machine.

### What changed:

- In our custom Processing dialog (BaseAlgorithmDialog), we no longer call setAlgorithm() immediately inside the dialog’s constructor. Instead, we schedule it to run one “tick” later using QTimer.singleShot(0, ...).
- In the AddImageCollectionAlgorithm, we added a guard so that on older QGIS versions (< 3.40) the plugin falls back to the stock Processing parameters form instead of trying to build our custom dialog.

### How to test it

- Open the image collection dialog on a Windows 11 machine
- Make sure no regressions are present (CI, some manual testing)

### Other notes

- Closes #407 
- On QGIS 3.28 (especially on Windows), calling setAlgorithm() too early in the dialog’s lifecycle can cause a native C++ crash (“Windows fatal exception: access violation”). Deferring the call gives Qt time to finish setting up the base dialog before wiring in the algorithm, which avoids the crash.
