### PR TITLE
fix: update bytes-per-pixel estimation to match EE Pixel accounting 

### DIFF
--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -73,20 +73,25 @@ def _bytes_for_data_type(dt: dict) -> int:
 def estimate_bytes_per_pixel(img: ee.Image) -> int:
     """Estimate bytes-per-pixel for an EE image by summing per-band sizes.
     Falls back to band_count * 2 when metadata is missing.
+    Adds one byte for the mask to match Earth Engine’s accounting.
     """
+    ee_mask_bytes = 1
     try:
         info = img.getInfo()
         bands_info = info.get("bands", []) if isinstance(info, dict) else []
         if bands_info:
-            return sum(_bytes_for_data_type(b.get("data_type", {})) for b in bands_info)
+            return sum(
+                _bytes_for_data_type(band.get("data_type", {})) + ee_mask_bytes
+                for band in bands_info
+            )
     except Exception as e:
         logger.debug(f"Could not read band data types from getInfo(): {e}")
     try:
         n_bands = img.bandNames().size().getInfo()
-        return int(n_bands) * 2
+        return int(n_bands) * (2 + ee_mask_bytes)
     except Exception as e:
         logger.debug(f"Could not read band count; defaulting to 2 bytes-per-pixel: {e}")
-        return 2
+        return 2 + ee_mask_bytes
 
 
 filter_functions = {


### PR DESCRIPTION

* Include mask byte in bytes-per-pixel estimation

Updated the estimate_bytes_per_pixel function to include a mask byte in the bytes-per-pixel calculation. Fixes https://github.com/google/Xee/issues/209

* Improve docstring and formatting in estimate_bytes_per_pixel

Refactor estimate_bytes_per_pixel function for clarity.