### PR TITLE
fix: Pin the earthengine-api to a specific version to ensure Python compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 ratelim
-earthengine-api>=1.5.12
+# Pin the earthengine-api to a specific version.
+# Later versions require Python 3.10 which is not supported by
+# QGIS mac builds as of 2025-12-04
+earthengine-api==1.6.15
 six>=1.13
 httplib2
 requests>2.4


### PR DESCRIPTION
 Pin the earthengine-api to a specific version as later versions require Python 3.10 which is not supported by many QGIS builds currently. Fixes https://github.com/gee-community/qgis-earthengine-plugin/issues/417.