### PR TITLE
fix: add gee tag to metadata.txt

### DIFF
--- a/ee_plugin/metadata.txt
+++ b/ee_plugin/metadata.txt
@@ -25,7 +25,7 @@ repository=https://github.com/gee-community/qgis-earthengine-plugin
 # changelog=
 
 # Tags are comma separated with spaces allowed
-tags=cloud, analysis, dem, geojson, geometry, google, landsat, land cover, processing, raster, remote sensing, statistics, topography, webservice
+tags=gee, cloud, analysis, dem, geojson, geometry, google, landsat, land cover, processing, raster, remote sensing, statistics, topography, webservice
 
 homepage=https://gee-community.github.io/qgis-earthengine-plugin/
 category=Plugins


### PR DESCRIPTION
As per the discussion in https://github.com/gee-community/qgis-earthengine-plugin/issues/420, adding a tag `gee` to metadata.txt to improve discoverability of the plugin.