### PR TITLE
fix: make pkg_resources optional for QGIS 3.44 compatibility

### DIFF
--- a/.python.env
+++ b/.python.env
@@ -1,1 +1,1 @@
-PYTHONPATH=${PYTHONPATH}:./extlibs:/Applications/QGIS-LTR.app/Contents/MacOS/lib/python3.9
+PYTHONPATH=${PYTHONPATH}:./extlibs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "python.envFile": "${workspaceFolder}/.python.env",
   "terminal.integrated.env.osx": {
-    "PYTHONPATH": "${PYTHONPATH}:./extlibs:/Applications/QGIS-LTR.app/Contents/MacOS/lib/python3.9"
+    "PYTHONPATH": "${PYTHONPATH}:./extlibs"
   },
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": [

--- a/ee_plugin/__init__.py
+++ b/ee_plugin/__init__.py
@@ -2,8 +2,6 @@
 import os
 import site
 
-import pkg_resources
-
 __version__ = "0.0.7"
 
 
@@ -15,8 +13,18 @@ def add_ee_dependencies():
     if os.path.isdir(extra_libs_path):
         # add to python path
         site.addsitedir(extra_libs_path)
-        # pkg_resources doesn't listen to changes on sys.path.
-        pkg_resources.working_set.add_entry(extra_libs_path)
+        # Older plugin code used pkg_resources to refresh setuptools'
+        # working set after mutating sys.path. QGIS 3.44 ships without
+        # pkg_resources by default, and the plugin does not otherwise
+        # require setuptools to function.
+        try:
+            import pkg_resources
+        except ModuleNotFoundError:
+            pkg_resources = None
+
+        if pkg_resources is not None:
+            # pkg_resources doesn't listen to changes on sys.path.
+            pkg_resources.working_set.add_entry(extra_libs_path)
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
## What I Changed

- Made `pkg_resources` optional during plugin startup in `ee_plugin/__init__.py`.
- Kept `ee_plugin/extlibs` loading via `site.addsitedir(...)` unchanged.
- Avoided a hard crash on QGIS 3.44 / Python 3.12 environments where `pkg_resources` is not installed by default.

## How to Test

1. Use QGIS 3.44.9 on macOS.
2. Ensure there is no stale `PYTHONPATH` pointing at an old Python 3.9 virtualenv in QGIS environment settings.
3. Install or symlink this plugin into the QGIS plugins directory.
4. Launch QGIS and enable the Google Earth Engine plugin.
5. Confirm the plugin loads past import without raising:
   `ModuleNotFoundError: No module named 'pkg_resources'`
6. Verify the plugin menu appears and basic startup behavior works normally.

## Other Notes

- This change is intended as a compatibility fix for newer QGIS/Python environments where `pkg_resources` is unavailable by default.
- Closes #425