### PR TITLE
fix: tighten extlibs build for QGIS plugin publishing

### DIFF
--- a/.github/workflows/actions/setup-extlibs/action.yml
+++ b/.github/workflows/actions/setup-extlibs/action.yml
@@ -7,7 +7,4 @@ runs:
     - name: Install plugin dependencies into extlibs
       shell: bash
       run: |
-        mkdir -p ee_plugin/extlibs
-        pip install -r requirements.txt -t ee_plugin/extlibs
-        find ee_plugin/extlibs -type f \( -name '*.so' -o -name '*.pyd' -o -name '*.dylib' \) -delete
-        find ee_plugin/extlibs -type d -name __pycache__ -exec rm -rf {} +
+        ./scripts/build_extlibs.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,11 @@ The plugin can be debugged within [Visual Studio Code](https://code.visualstudio
 
 4. Test your changes locally including reinstalling new dependencies for the QGIS environment with:
    ```bash
-   pip install -r requirements.txt -t ee_plugin/extlibs  
+   ./scripts/build_extlibs.sh
    ```
+
+   This rebuilds `ee_plugin/extlibs` the same way CI and publishing do, including
+   cleanup/pruning of vendored dependencies that are not shipped in releases.
 
 5. Commit your changes with a clear and descriptive message:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,11 @@ ratelim
 # Later versions require Python 3.10 which is not supported by
 # QGIS mac builds as of 2025-12-04
 earthengine-api==1.6.15
+# Pin the Google auth/client stack to versions that still import cleanly
+# without vendored cryptography in the QGIS plugin environment.
+google-auth==2.40.3
+google-auth-httplib2==0.3.1
+google-api-python-client==2.195.0
 six>=1.13
 httplib2
 requests>2.4

--- a/scripts/build_extlibs.sh
+++ b/scripts/build_extlibs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXTLIBS_DIR="$ROOT_DIR/ee_plugin/extlibs"
+
+rm -rf "$EXTLIBS_DIR"
+mkdir -p "$EXTLIBS_DIR"
+
+pip install --no-compile -r "$ROOT_DIR/requirements.txt" -t "$EXTLIBS_DIR"
+
+# Keep the vendored bundle to runtime-only dependencies used by the plugin.
+# Earth Engine's CLI / Cloud Storage helper stack pulls in crypto packages
+# that QGIS plugin repository scanning now blocks, but the plugin imports
+# only the EE client library and requests stack.
+rm -rf "$EXTLIBS_DIR/bin"
+rm -rf "$EXTLIBS_DIR/ee/cli"
+rm -rf "$EXTLIBS_DIR/google/cloud/storage"
+rm -rf "$EXTLIBS_DIR/google_crc32c"
+rm -rf "$EXTLIBS_DIR/cryptography"
+rm -rf "$EXTLIBS_DIR/cffi"
+rm -rf "$EXTLIBS_DIR/pycparser"
+rm -rf "$EXTLIBS_DIR"/google_cloud_storage-*.dist-info
+rm -rf "$EXTLIBS_DIR"/google_crc32c-*.dist-info
+rm -rf "$EXTLIBS_DIR"/google_resumable_media-*.dist-info
+rm -rf "$EXTLIBS_DIR"/cryptography-*.dist-info
+rm -rf "$EXTLIBS_DIR"/cffi-*.dist-info
+rm -rf "$EXTLIBS_DIR"/pycparser-*.dist-info
+
+# Tests are not needed in the packaged plugin and add scan noise.
+find "$EXTLIBS_DIR" -type d \( -name tests -o -name testing \) -prune -exec rm -rf {} +
+find "$EXTLIBS_DIR" -type f \( -name '*.so' -o -name '*.pyd' -o -name '*.dylib' \) -delete
+find "$EXTLIBS_DIR" -type d -name __pycache__ -exec rm -rf {} +


### PR DESCRIPTION
## What I Changed

This updates how `ee_plugin/extlibs` is built and maintained for releases.

- Added a shared `scripts/build_extlibs.sh` script so local builds and CI use the same extlibs packaging flow
- Updated the GitHub Actions extlibs setup step to call that shared script
- Updated `CONTRIBUTING.md` to point contributors at the shared extlibs build command instead of the old one-off `pip install -t ...` instruction
- Rebuild extlibs from a clean directory each time instead of layering installs over existing contents
- Pruned non-runtime vendored dependencies and packaging/test artifacts from the release bundle
- Pinned the Google auth/client dependency stack to versions that still work in the QGIS plugin environment without requiring the vendored `cryptography` path that was causing publication/runtime issues

## Why

`0.1.8` was uploaded to the QGIS Plugin Repository, but it was blocked by the new security scan due to critical findings in the vendored third-party dependencies under `ee_plugin/extlibs`, especially `cffi` and `cryptography`.

At the same time, rebuilding `extlibs` without tighter dependency control caused drift in transitive Google auth packages, which changed import behavior in QGIS and broke plugin startup.

This change addresses both problems by:
- making the extlibs build reproducible
- reducing the vendored dependency set to the runtime subset the plugin actually needs
- pinning the auth/client stack so local and release builds do not drift onto incompatible transitive versions

## How to Test

1. Run:
   ```bash
    ./scripts/build_extlibs.sh
   ```
2. Confirm the rebuilt bundle includes ee and the pinned auth/client packages.
3. Symlink or install the repo copy of ee_plugin into the QGIS plugins directory.
4. Restart QGIS and verify the plugin loads successfully.
5. Verify core plugin flows still work:
    - authentication
    - add EE image
    - add EE image collection
    - export flow used by the plugin
6. Confirm CI/release packaging uses the same extlibs build path.

## Other Notes

Closes #428 