### PR TITLE
fix: plugin audit

### DIFF
--- a/ee_plugin/metadata.txt
+++ b/ee_plugin/metadata.txt
@@ -8,7 +8,7 @@
 
 [general]
 name=Google Earth Engine
-qgisMinimumVersion=3.22
+qgisMinimumVersion=3.44
 description=Integrates QGIS with Google Earth Engine
 author=Gennadii Donchyts, Xavier C. Llano, Fedor Baart, Zac Deziel, Anthony Lukach
 email=gennadiy.donchyts@gmail.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,7 @@
 ratelim
-# Pin the earthengine-api to a specific version.
-# Later versions require Python 3.10 which is not supported by
-# QGIS mac builds as of 2025-12-04
-earthengine-api==1.6.15
-# Pin the Google auth/client stack to versions that still import cleanly
-# without vendored cryptography in the QGIS plugin environment.
-google-auth==2.40.3
-google-auth-httplib2==0.3.1
-google-api-python-client==2.195.0
+# Track the modern Earth Engine client line now that the plugin baseline
+# targets supported QGIS releases shipping Python 3.12+.
+earthengine-api==1.7.25
 six>=1.13
 httplib2
 requests>2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ratelim
 # Track the modern Earth Engine client line now that the plugin baseline
 # targets supported QGIS releases shipping Python 3.12+.
 earthengine-api==1.7.25

--- a/scripts/build_extlibs.sh
+++ b/scripts/build_extlibs.sh
@@ -27,6 +27,8 @@ rm -rf "$EXTLIBS_DIR/bin"
 rm -rf "$EXTLIBS_DIR/ee/cli"
 rm -rf "$EXTLIBS_DIR/google/cloud/storage"
 rm -rf "$EXTLIBS_DIR/google_crc32c"
+rm -rf "$EXTLIBS_DIR/google/resumable_media"
+rm -rf "$EXTLIBS_DIR/google/_async_resumable_media"
 rm -rf "$EXTLIBS_DIR"/google_cloud_storage-*.dist-info
 rm -rf "$EXTLIBS_DIR"/google_crc32c-*.dist-info
 rm -rf "$EXTLIBS_DIR"/google_resumable_media-*.dist-info

--- a/scripts/build_extlibs.sh
+++ b/scripts/build_extlibs.sh
@@ -5,30 +5,32 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 EXTLIBS_DIR="$ROOT_DIR/ee_plugin/extlibs"
 
+if [[ -n "${EXTLIBS_PYTHON:-}" ]]; then
+  PYTHON_BIN="$EXTLIBS_PYTHON"
+elif command -v python3.12 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3.12)"
+elif [[ -x "/Applications/QGIS.app/Contents/MacOS/python3.12" ]]; then
+  PYTHON_BIN="/Applications/QGIS.app/Contents/MacOS/python3.12"
+else
+  PYTHON_BIN="$(command -v python3)"
+fi
+
 rm -rf "$EXTLIBS_DIR"
 mkdir -p "$EXTLIBS_DIR"
 
-pip install --no-compile -r "$ROOT_DIR/requirements.txt" -t "$EXTLIBS_DIR"
+env -u PYTHONHOME -u PYTHONPATH "$PYTHON_BIN" -m pip install --no-compile -r "$ROOT_DIR/requirements.txt" -t "$EXTLIBS_DIR"
 
 # Keep the vendored bundle to runtime-only dependencies used by the plugin.
-# Earth Engine's CLI / Cloud Storage helper stack pulls in crypto packages
-# that QGIS plugin repository scanning now blocks, but the plugin imports
-# only the EE client library and requests stack.
+# Newer Earth Engine / google-auth releases require cryptography at runtime,
+# so we only prune optional Cloud Storage and CLI helpers here.
 rm -rf "$EXTLIBS_DIR/bin"
 rm -rf "$EXTLIBS_DIR/ee/cli"
 rm -rf "$EXTLIBS_DIR/google/cloud/storage"
 rm -rf "$EXTLIBS_DIR/google_crc32c"
-rm -rf "$EXTLIBS_DIR/cryptography"
-rm -rf "$EXTLIBS_DIR/cffi"
-rm -rf "$EXTLIBS_DIR/pycparser"
 rm -rf "$EXTLIBS_DIR"/google_cloud_storage-*.dist-info
 rm -rf "$EXTLIBS_DIR"/google_crc32c-*.dist-info
 rm -rf "$EXTLIBS_DIR"/google_resumable_media-*.dist-info
-rm -rf "$EXTLIBS_DIR"/cryptography-*.dist-info
-rm -rf "$EXTLIBS_DIR"/cffi-*.dist-info
-rm -rf "$EXTLIBS_DIR"/pycparser-*.dist-info
 
 # Tests are not needed in the packaged plugin and add scan noise.
 find "$EXTLIBS_DIR" -type d \( -name tests -o -name testing \) -prune -exec rm -rf {} +
-find "$EXTLIBS_DIR" -type f \( -name '*.so' -o -name '*.pyd' -o -name '*.dylib' \) -delete
 find "$EXTLIBS_DIR" -type d -name __pycache__ -exec rm -rf {} +


### PR DESCRIPTION
## What I Changed

This updates the plugin’s vendored dependency build to match the current QGIS runtime baseline and trims unused packages from the published extlibs bundle.

- Raised the minimum supported QGIS version to 3.44
- Updated the vendored Earth Engine dependency to `earthengine-api==1.7.25`
- Removed older manual auth/client pinning that was only needed for the previous compatibility baseline
- Updated the extlibs build script to install with Python 3.12 so native modules match the QGIS runtime ABI
- Stopped stripping required runtime native dependencies like `cryptography` and `cffi`
- Removed unused vendored dependencies such as `ratelim`, `decorator`, and Google resumable media helpers from the release bundle

## Why

The previous extlibs build was carrying older dependency constraints for legacy QGIS compatibility and was also vulnerable to ABI mismatches when built with a different Python version than the one bundled with QGIS.

At the same time, the QGIS Plugin Repository security scan was flagging issues in unused vendored packages that were being bundled but not required for plugin runtime.

This change modernizes the dependency baseline to align with supported QGIS releases and reduces the published vendored dependency surface before addressing any remaining scanner findings in the core Earth Engine runtime set.

## How to Test

1. Run:
   ```bash
   ./scripts/build_extlibs.sh

2. Confirm the rebuilt extlibs bundle contains Python 3.12-compatible native modules.
3. Restart QGIS 3.44 and verify the plugin loads successfully.
4. Upload the rebuilt plugin package and review the updated QGIS Plugin Repository security scan results.