### PR TITLE
fix: avoid full refreshes for EE raster layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,12 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install uv
+        if: ${{ !env.ACT }}
         uses: astral-sh/setup-uv@v6
+
+      - name: Install uv for act
+        if: ${{ env.ACT }}
+        run: python3 -m pip install --break-system-packages uv
 
       - name: Create virtualenv and install dependencies
         run: |

--- a/ee_plugin/processing/export_geotiff.py
+++ b/ee_plugin/processing/export_geotiff.py
@@ -38,7 +38,7 @@ from qgis.core import (
 
 from ..logging import local_context
 from .. import Map
-from ..utils import ee_image_to_geotiff
+from ..utils import ee_image_to_geotiff, get_ee_object_from_layer, is_ee_raster_layer
 
 
 logging = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class ExportGeoTIFFAlgorithmDialog(BaseAlgorithmDialog):
         self._raster_layers: List[str] = [
             layer.name()
             for layer in Map.get_iface().mapCanvas().layers()
-            if layer.providerType() == "EE"
+            if is_ee_raster_layer(layer)
         ]
         self._bands_cache: dict[str, List[str]] = {}
         super().__init__(algorithm, parent=parent, title="Export Image to GeoTIFF")
@@ -169,7 +169,7 @@ class ExportGeoTIFFAlgorithmDialog(BaseAlgorithmDialog):
                 (
                     layer
                     for layer in Map.get_iface().mapCanvas().layers()
-                    if layer.name() == name and layer.providerType() == "EE"
+                    if layer.name() == name and is_ee_raster_layer(layer)
                 ),
                 None,
             )
@@ -177,7 +177,7 @@ class ExportGeoTIFFAlgorithmDialog(BaseAlgorithmDialog):
                 bands = []
             else:
                 try:
-                    ee_image = layer.dataProvider().ee_object
+                    ee_image = get_ee_object_from_layer(layer)
                     bands = ee_image.bandNames().getInfo() or []
                 except Exception:
                     bands = []
@@ -265,7 +265,7 @@ class ExportGeoTIFFAlgorithm(QgsProcessingAlgorithm):
         raster_layers = [
             layer.name()
             for layer in Map.get_iface().mapCanvas().layers()
-            if layer.providerType() == "EE"
+            if is_ee_raster_layer(layer)
         ]
 
         if not raster_layers:
@@ -347,7 +347,7 @@ class ExportGeoTIFFAlgorithm(QgsProcessingAlgorithm):
             (
                 layer
                 for layer in Map.get_iface().mapCanvas().layers()
-                if layer.name() == ee_img and layer.providerType() == "EE"
+                if layer.name() == ee_img and is_ee_raster_layer(layer)
             ),
             None,
         )
@@ -356,7 +356,11 @@ class ExportGeoTIFFAlgorithm(QgsProcessingAlgorithm):
             msg = f"Layer {ee_img} not found"
             raise ValueError(msg)
 
-        ee_image = layer.dataProvider().ee_object
+        ee_image = get_ee_object_from_layer(layer)
+        if ee_image is None:
+            raise ValueError(
+                f"Could not restore Earth Engine object for layer {ee_img}"
+            )
 
         # Optional band selection
         bands_param = parameters.get("BANDS")

--- a/ee_plugin/processing/export_geotiff.py
+++ b/ee_plugin/processing/export_geotiff.py
@@ -38,7 +38,13 @@ from qgis.core import (
 
 from ..logging import local_context
 from .. import Map
-from ..utils import ee_image_to_geotiff, get_ee_object_from_layer, is_ee_raster_layer
+from ..utils import (
+    ee_image_to_geotiff,
+    get_ee_object_from_layer,
+    get_ee_raster_layers,
+    get_layer_by_name,
+    is_ee_raster_layer,
+)
 
 
 logging = logging.getLogger(__name__)
@@ -51,9 +57,7 @@ class ExportGeoTIFFAlgorithmDialog(BaseAlgorithmDialog):
         self, algorithm: QgsProcessingAlgorithm, parent: Optional[QWidget] = None
     ):
         self._raster_layers: List[str] = [
-            layer.name()
-            for layer in Map.get_iface().mapCanvas().layers()
-            if is_ee_raster_layer(layer)
+            layer.name() for layer in get_ee_raster_layers()
         ]
         self._bands_cache: dict[str, List[str]] = {}
         super().__init__(algorithm, parent=parent, title="Export Image to GeoTIFF")
@@ -168,7 +172,7 @@ class ExportGeoTIFFAlgorithmDialog(BaseAlgorithmDialog):
             layer = next(
                 (
                     layer
-                    for layer in Map.get_iface().mapCanvas().layers()
+                    for layer in get_ee_raster_layers()
                     if layer.name() == name and is_ee_raster_layer(layer)
                 ),
                 None,
@@ -262,11 +266,7 @@ class ExportGeoTIFFAlgorithm(QgsProcessingAlgorithm):
     OUTPUT = "OUTPUT"
 
     def initAlgorithm(self, config: dict) -> None:
-        raster_layers = [
-            layer.name()
-            for layer in Map.get_iface().mapCanvas().layers()
-            if is_ee_raster_layer(layer)
-        ]
+        raster_layers = [layer.name() for layer in get_ee_raster_layers()]
 
         if not raster_layers:
             logging.warning(
@@ -343,16 +343,9 @@ class ExportGeoTIFFAlgorithm(QgsProcessingAlgorithm):
         if feedback.isCanceled():
             raise RuntimeError("Canceled")
 
-        layer = next(
-            (
-                layer
-                for layer in Map.get_iface().mapCanvas().layers()
-                if layer.name() == ee_img and is_ee_raster_layer(layer)
-            ),
-            None,
-        )
+        layer = get_layer_by_name(ee_img)
 
-        if not layer:
+        if not layer or not is_ee_raster_layer(layer):
             msg = f"Layer {ee_img} not found"
             raise ValueError(msg)
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -146,6 +146,24 @@ def get_layer_by_name(name: str) -> Optional[QgsMapLayer]:
     return layers[0] if layers else None
 
 
+def get_ee_raster_layers() -> list[QgsMapLayer]:
+    iface = getattr(qgis.utils, "iface", None)
+    canvas_layer_ids = set()
+    raster_layers = []
+
+    if iface:
+        for layer in iface.mapCanvas().layers():
+            if is_ee_raster_layer(layer):
+                raster_layers.append(layer)
+                canvas_layer_ids.add(layer.id())
+
+    for layer in QgsProject.instance().mapLayers().values():
+        if is_ee_raster_layer(layer) and layer.id() not in canvas_layer_ids:
+            raster_layers.append(layer)
+
+    return raster_layers
+
+
 def get_ee_image_url(image: ee.Image) -> str:
     map_id = ee.data.getMapId({"image": image})
     url = map_id["tile_fetcher"].url_format

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -33,6 +33,12 @@ from qgis.PyQt.QtCore import QCoreApplication
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)  # Change as needed (DEBUG/INFO/WARNING/ERROR)
 
+EE_LAYER_PROPERTY = "ee-layer"
+EE_LAYER_TYPE_PROPERTY = "ee-layer-type"
+EE_OBJECT_PROPERTY = "ee-object"
+EE_OBJECT_VIS_PROPERTY = "ee-object-vis"
+EE_ASSET_ID_PROPERTY = "ee-asset-id"
+
 # --- Encoding-size helpers (module-level; used by tile_extent) ---
 
 
@@ -138,6 +144,53 @@ def get_ee_image_url(image: ee.Image) -> str:
     return url
 
 
+def _serialize_ee_object(ee_object: ee.Element) -> str:
+    return ee.serializer.toJSON(ee_object)
+
+
+def set_ee_layer_properties(
+    layer: QgsMapLayer,
+    ee_object: ee.Element,
+    vis_params: Optional[VisualizeParams] = None,
+    layer_type: str = "raster",
+) -> None:
+    layer.setCustomProperty(EE_LAYER_PROPERTY, True)
+    layer.setCustomProperty(EE_LAYER_TYPE_PROPERTY, layer_type)
+    layer.setCustomProperty(EE_OBJECT_PROPERTY, _serialize_ee_object(ee_object))
+    layer.setCustomProperty(EE_OBJECT_VIS_PROPERTY, json.dumps(vis_params or {}))
+    try:
+        asset_id = ee_object.id().getInfo() if hasattr(ee_object, "id") else None
+    except Exception:
+        asset_id = None
+    if asset_id:
+        layer.setCustomProperty(EE_ASSET_ID_PROPERTY, asset_id)
+
+
+def is_ee_layer(layer: QgsMapLayer) -> bool:
+    return bool(layer and layer.customProperty(EE_LAYER_PROPERTY))
+
+
+def is_ee_raster_layer(layer: QgsMapLayer) -> bool:
+    return bool(
+        is_ee_layer(layer) and layer.customProperty(EE_LAYER_TYPE_PROPERTY) == "raster"
+    )
+
+
+def get_ee_object_from_layer(layer: QgsMapLayer) -> Optional[ee.Element]:
+    if not is_ee_layer(layer):
+        return None
+    serialized = layer.customProperty(EE_OBJECT_PROPERTY)
+    if serialized:
+        try:
+            return ee.deserializer.fromJSON(serialized)
+        except Exception as e:
+            logger.warning(
+                f"Could not deserialize ee object from layer {layer.name()}: {e}"
+            )
+    provider_object = getattr(layer.dataProvider(), "ee_object", None)
+    return provider_object
+
+
 def add_or_update_ee_layer(
     eeObject: ee.Element,
     vis_params: VisualizeParams,
@@ -193,7 +246,7 @@ def add_or_update_ee_raster_layer(
 ) -> QgsRasterLayer:
     logger.debug(f"Adding/updating EE raster layer: {name}")
     layer = get_layer_by_name(name)
-    if layer and layer.customProperty("ee-layer"):
+    if layer and is_ee_layer(layer):
         return update_ee_image_layer(image, layer, vis_params, shown, opacity)
     return add_ee_image_layer(image, name, vis_params, shown, opacity)
 
@@ -208,7 +261,7 @@ def add_ee_image_layer(
     logger.debug(f"Adding EE image layer: {name}")
     check_version()
     url = "type=xyz&url=" + get_ee_image_url(image.visualize(**vis_params))
-    layer = QgsRasterLayer(url, name, "EE")
+    layer = QgsRasterLayer(url, name, "wms")
     # Set extent from ee_object geometry
     try:
         bounds = image.geometry().bounds().getInfo()["coordinates"][0]
@@ -219,7 +272,7 @@ def add_ee_image_layer(
     except Exception as e:
         logger.warning(f"Could not set layer extent from ee_object: {e}")
     assert layer.isValid(), f"Failed to load layer: {name}"
-    layer.dataProvider().set_ee_object(image)
+    set_ee_layer_properties(layer, image, vis_params, layer_type="raster")
     QgsProject.instance().addMapLayer(layer)
 
     if opacity is not None and layer.renderer():
@@ -244,7 +297,8 @@ def update_ee_image_layer(
     parent_group = layer_node.parent()
     idx = parent_group.children().index(layer_node)
 
-    new_layer = QgsRasterLayer(url, layer.name(), "EE")
+    new_layer = QgsRasterLayer(url, layer.name(), "wms")
+    set_ee_layer_properties(new_layer, image, vis_params, layer_type="raster")
 
     if opacity is not None and new_layer.renderer():
         new_layer.renderer().setOpacity(opacity)
@@ -332,6 +386,7 @@ def add_ee_vector_layer(
     uri = temp_file.name
     layer = QgsVectorLayer(uri, name, "ogr")
     assert layer.isValid(), f"Failed to load vector layer: {name}"
+    set_ee_layer_properties(layer, eeObject, style_params or {}, layer_type="vector")
 
     QgsProject.instance().addMapLayer(layer)
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -142,9 +142,7 @@ def get_layer_by_name(name: str) -> Optional[QgsMapLayer]:
             return canvas_layers[0]
 
     layers = QgsProject.instance().mapLayersByName(name)
-    logger.debug(
-        f"Found {len(layers)} project layer(s) with name '{name}'."
-    )
+    logger.debug(f"Found {len(layers)} project layer(s) with name '{name}'.")
     return layers[0] if layers else None
 
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -286,7 +286,6 @@ def add_ee_image_layer(
     check_version()
     url = "type=xyz&url=" + get_ee_image_url(image.visualize(**vis_params))
     layer = QgsRasterLayer(url, name, "wms")
-    set_layer_extent_from_ee_object(layer, image, "layer extent")
     assert layer.isValid(), f"Failed to load layer: {name}"
     set_ee_layer_properties(layer, image, vis_params, layer_type="raster")
     QgsProject.instance().addMapLayer(layer)
@@ -310,7 +309,6 @@ def update_ee_image_layer(
     layer.setDataSource(url, layer.name(), "wms")
     assert layer.isValid(), f"Failed to update layer: {layer.name()}"
     set_ee_layer_properties(layer, image, vis_params, layer_type="raster")
-    set_layer_extent_from_ee_object(layer, image, "updated layer extent")
 
     if opacity is not None and layer.renderer():
         layer.renderer().setOpacity(opacity)

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -143,9 +143,9 @@ def get_layer_by_name(name: str) -> Optional[QgsMapLayer]:
 
     layers = QgsProject.instance().mapLayersByName(name)
     logger.debug(
-        f"Found {len(layers)} project layers with name '{name}' but none on the canvas."
+        f"Found {len(layers)} project layer(s) with name '{name}'."
     )
-    return None
+    return layers[0] if layers else None
 
 
 def get_ee_image_url(image: ee.Image) -> str:

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -132,9 +132,20 @@ def is_named_dataset(eeObject: ee.Element) -> bool:
 
 
 def get_layer_by_name(name: str) -> Optional[QgsMapLayer]:
+    iface = getattr(qgis.utils, "iface", None)
+    if iface:
+        canvas_layers = [
+            layer for layer in iface.mapCanvas().layers() if layer.name() == name
+        ]
+        logger.debug(f"Found {len(canvas_layers)} canvas layers with name '{name}'.")
+        if canvas_layers:
+            return canvas_layers[0]
+
     layers = QgsProject.instance().mapLayersByName(name)
-    logger.debug(f"Found {len(layers)} layers with name '{name}'.")
-    return layers[0] if layers else None
+    logger.debug(
+        f"Found {len(layers)} project layers with name '{name}' but none on the canvas."
+    )
+    return None
 
 
 def get_ee_image_url(image: ee.Image) -> str:
@@ -142,6 +153,19 @@ def get_ee_image_url(image: ee.Image) -> str:
     url = map_id["tile_fetcher"].url_format
     logger.debug(f"Generated EE image URL: {url}")
     return url
+
+
+def set_layer_extent_from_ee_object(
+    layer: QgsMapLayer, ee_object: ee.Element, warning_context: str
+) -> None:
+    try:
+        bounds = ee_object.geometry().bounds().getInfo()["coordinates"][0]
+        xs = [pt[0] for pt in bounds]
+        ys = [pt[1] for pt in bounds]
+        rect = QgsRectangle(min(xs), min(ys), max(xs), max(ys))
+        layer.setExtent(rect)
+    except Exception as e:
+        logger.warning(f"Could not set {warning_context} from ee_object: {e}")
 
 
 def _serialize_ee_object(ee_object: ee.Element) -> str:
@@ -262,15 +286,7 @@ def add_ee_image_layer(
     check_version()
     url = "type=xyz&url=" + get_ee_image_url(image.visualize(**vis_params))
     layer = QgsRasterLayer(url, name, "wms")
-    # Set extent from ee_object geometry
-    try:
-        bounds = image.geometry().bounds().getInfo()["coordinates"][0]
-        xs = [pt[0] for pt in bounds]
-        ys = [pt[1] for pt in bounds]
-        rect = QgsRectangle(min(xs), min(ys), max(xs), max(ys))
-        layer.setExtent(rect)
-    except Exception as e:
-        logger.warning(f"Could not set layer extent from ee_object: {e}")
+    set_layer_extent_from_ee_object(layer, image, "layer extent")
     assert layer.isValid(), f"Failed to load layer: {name}"
     set_ee_layer_properties(layer, image, vis_params, layer_type="raster")
     QgsProject.instance().addMapLayer(layer)
@@ -291,26 +307,21 @@ def update_ee_image_layer(
     logger.debug(f"Updating EE image layer: {layer.name()}")
     check_version()
     url = "type=xyz&url=" + get_ee_image_url(image.visualize(**vis_params))
-    qgis_instance = QgsProject.instance()
-    root = qgis_instance.layerTreeRoot()
-    layer_node = root.findLayer(layer.id())
-    parent_group = layer_node.parent()
-    idx = parent_group.children().index(layer_node)
+    layer.setDataSource(url, layer.name(), "wms")
+    assert layer.isValid(), f"Failed to update layer: {layer.name()}"
+    set_ee_layer_properties(layer, image, vis_params, layer_type="raster")
+    set_layer_extent_from_ee_object(layer, image, "updated layer extent")
 
-    new_layer = QgsRasterLayer(url, layer.name(), "wms")
-    set_ee_layer_properties(new_layer, image, vis_params, layer_type="raster")
-
-    if opacity is not None and new_layer.renderer():
-        new_layer.renderer().setOpacity(opacity)
-
-    qgis_instance.removeMapLayers([layer.id()])
-    qgis_instance.addMapLayer(new_layer, False)
-    root.insertLayer(idx, new_layer)
+    if opacity is not None and layer.renderer():
+        layer.renderer().setOpacity(opacity)
 
     if shown is not None:
-        root.findLayer(new_layer.id()).setItemVisibilityChecked(shown)
+        layer_node = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
+        if layer_node:
+            layer_node.setItemVisibilityChecked(shown)
 
-    return new_layer
+    layer.triggerRepaint()
+    return layer
 
 
 def add_or_update_named_vector_layer(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 import ee
 from pytest import fixture
+from qgis.core import QgsProject
 from qgis.gui import QgisInterface
 from qgis.PyQt.QtCore import QSettings, QCoreApplication
 from qgis.utils import plugins
@@ -38,5 +39,8 @@ def load_ee_plugin(qgis_app, setup_ee, ee_config):
 
 @fixture(autouse=True, scope="function")
 def clean_qgis_iface(qgis_iface: QgisInterface):
+    QgsProject.instance().removeAllMapLayers()
     qgis_iface.mapCanvas().setLayers([])
     yield qgis_iface
+    QgsProject.instance().removeAllMapLayers()
+    qgis_iface.mapCanvas().setLayers([])

--- a/test/test_add_ee_image.py
+++ b/test/test_add_ee_image.py
@@ -22,7 +22,8 @@ def test_add_gee_layer_algorithm(clean_qgis_iface):
     run_algorithm_with_params(params)
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "USGS/SRTMGL1_003"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_load_gee_layer_srtm(clean_qgis_iface):
@@ -33,7 +34,8 @@ def test_load_gee_layer_srtm(clean_qgis_iface):
     run_algorithm_with_params(params)
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "USGS/SRTMGL1_003"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_converting_viz_params_json(clean_qgis_iface):
@@ -44,7 +46,8 @@ def test_converting_viz_params_json(clean_qgis_iface):
     run_algorithm_with_params(params)
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "USGS/SRTMGL1_003"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_invalid_viz_params(clean_qgis_iface):
@@ -65,4 +68,5 @@ def test_empty_viz_params(clean_qgis_iface):
     run_algorithm_with_params(params)
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "USGS/SRTMGL1_003"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"

--- a/test/test_add_ee_image.py
+++ b/test/test_add_ee_image.py
@@ -4,6 +4,7 @@ from qgis.core import (
     QgsProcessingFeedback,
 )
 from ee_plugin.processing.add_ee_image import AddEEImageAlgorithm
+from ee_plugin.utils import get_layer_by_name
 
 
 def run_algorithm_with_params(params):
@@ -20,7 +21,7 @@ def test_add_gee_layer_algorithm(clean_qgis_iface):
         "VIZ_PARAMS": '{"min": 0, "max": 3000, "palette": ["#000000", "#ffffff"]}',
     }
     run_algorithm_with_params(params)
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("USGS/SRTMGL1_003")
     assert layer.name() == "USGS/SRTMGL1_003"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -32,7 +33,7 @@ def test_load_gee_layer_srtm(clean_qgis_iface):
         "VIZ_PARAMS": '{"min": 0, "max": 4000, "palette": ["006633", "E5FFCC", "662A00"]}',
     }
     run_algorithm_with_params(params)
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("USGS/SRTMGL1_003")
     assert layer.name() == "USGS/SRTMGL1_003"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -44,7 +45,7 @@ def test_converting_viz_params_json(clean_qgis_iface):
         "VIZ_PARAMS": "{'min': 0, 'max': 4000, 'palette': ['006633', 'E5FFCC', '662A00']}",
     }
     run_algorithm_with_params(params)
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("USGS/SRTMGL1_003")
     assert layer.name() == "USGS/SRTMGL1_003"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -66,7 +67,7 @@ def test_empty_viz_params(clean_qgis_iface):
         "VIZ_PARAMS": "",
     }
     run_algorithm_with_params(params)
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("USGS/SRTMGL1_003")
     assert layer.name() == "USGS/SRTMGL1_003"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"

--- a/test/test_add_feature_collection.py
+++ b/test/test_add_feature_collection.py
@@ -32,7 +32,8 @@ def test_add_feature_collection_algorithm_retain_vector(clean_qgis_iface):
         assert False, "No layers found in the map canvas."
     assert layer is not None
     assert layer.name() == "FC: USGS/WBD/2017/HUC06"
-    assert layer.providerType() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_add_feature_collection_algorithm(clean_qgis_iface):
@@ -70,4 +71,5 @@ def test_add_feature_collection_algorithm(clean_qgis_iface):
         assert False, "No layers found in the map canvas."
     assert layer is not None
     assert layer.name() == "FC: USGS/WBD/2017/HUC06"
-    assert layer.providerType() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"

--- a/test/test_add_feature_collection.py
+++ b/test/test_add_feature_collection.py
@@ -1,3 +1,6 @@
+from ee_plugin.utils import get_layer_by_name
+
+
 def test_add_feature_collection_algorithm_retain_vector(clean_qgis_iface):
     from ee_plugin.processing.add_feature_collection import (
         AddFeatureCollectionAlgorithm,
@@ -26,10 +29,7 @@ def test_add_feature_collection_algorithm_retain_vector(clean_qgis_iface):
 
     assert isinstance(result, dict)
     assert "OUTPUT_RASTER" in result
-    try:
-        layer = clean_qgis_iface.mapCanvas().layers()[0]
-    except IndexError:
-        assert False, "No layers found in the map canvas."
+    layer = get_layer_by_name("FC: USGS/WBD/2017/HUC06")
     assert layer is not None
     assert layer.name() == "FC: USGS/WBD/2017/HUC06"
     assert layer.customProperty("ee-layer")
@@ -65,10 +65,7 @@ def test_add_feature_collection_algorithm(clean_qgis_iface):
 
     assert isinstance(result, dict)
     assert "OUTPUT_RASTER" in result
-    try:
-        layer = clean_qgis_iface.mapCanvas().layers()[0]
-    except IndexError:
-        assert False, "No layers found in the map canvas."
+    layer = get_layer_by_name("FC: USGS/WBD/2017/HUC06")
     assert layer is not None
     assert layer.name() == "FC: USGS/WBD/2017/HUC06"
     assert layer.customProperty("ee-layer")

--- a/test/test_add_image_collection.py
+++ b/test/test_add_image_collection.py
@@ -2,6 +2,7 @@ import ee
 from qgis.core import QgsMapLayer
 
 from ee_plugin import Map
+from ee_plugin.utils import get_layer_by_name
 
 
 def test_add_landsat_cloud_cover(clean_qgis_iface):
@@ -11,10 +12,8 @@ def test_add_landsat_cloud_cover(clean_qgis_iface):
         .filter(ee.Filter.lt("CLOUD_COVER", 10))
     )
     Map.addLayer(collection, {}, "LANDSAT_2021")
-    layers = clean_qgis_iface.mapCanvas().layers()
-    assert len(layers) == 1
-    assert layers[0]
-    layer = layers[0]
+    layer = get_layer_by_name("LANDSAT_2021")
+    assert layer is not None
     assert layer.name() == "LANDSAT_2021"
     assert layer.type() == QgsMapLayer.LayerType.RasterLayer
     assert layer.customProperty("ee-layer")

--- a/test/test_add_image_collection.py
+++ b/test/test_add_image_collection.py
@@ -17,4 +17,5 @@ def test_add_landsat_cloud_cover(clean_qgis_iface):
     layer = layers[0]
     assert layer.name() == "LANDSAT_2021"
     assert layer.type() == QgsMapLayer.LayerType.RasterLayer
-    assert layer.providerType() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"

--- a/test/test_form_add_image_collection.py
+++ b/test/test_form_add_image_collection.py
@@ -41,7 +41,8 @@ def test_add_image_collection_algorithm_with_filters(clean_qgis_iface):
     # Validate that the layer was added to the map
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_add_image_collection_algorithm_multiple_filters(clean_qgis_iface):
@@ -66,7 +67,8 @@ def test_add_image_collection_algorithm_multiple_filters(clean_qgis_iface):
     # Validate that the layer was added to the map
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_invalid_filters(clean_qgis_iface):
@@ -117,7 +119,8 @@ def test_add_image_collection_algorithm_empty_filters(clean_qgis_iface):
     # Validate that the layer was added to the map
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_add_image_collection_algorithm_percentile_compositing(clean_qgis_iface):
@@ -142,7 +145,8 @@ def test_add_image_collection_algorithm_percentile_compositing(clean_qgis_iface)
     # Validate that the layer was added to the map with the correct compositing method
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Percentile 90%)"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 def test_add_image_collection_algorithm_invalid_json_viz_params(clean_qgis_iface):
@@ -191,7 +195,8 @@ def test_empty_viz_params(clean_qgis_iface):
     # Validate that the layer was added to the map
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"
 
 
 # Parametrized test for different extent CRS cases
@@ -229,4 +234,5 @@ def test_add_image_collection_with_varied_extent_crs(
     run_algorithm_with_params(params)
     layer = clean_qgis_iface.mapCanvas().layers()[0]
     assert layer.name().startswith("IC:")
-    assert layer.dataProvider().name() == "EE"
+    assert layer.customProperty("ee-layer")
+    assert layer.customProperty("ee-layer-type") == "raster"

--- a/test/test_form_add_image_collection.py
+++ b/test/test_form_add_image_collection.py
@@ -9,6 +9,7 @@ from qgis.core import (
 )
 
 from ee_plugin.processing.add_image_collection import AddImageCollectionAlgorithm
+from ee_plugin.utils import get_layer_by_name
 
 
 def run_algorithm_with_params(params):
@@ -39,7 +40,7 @@ def test_add_image_collection_algorithm_with_filters(clean_qgis_iface):
     run_algorithm_with_params(params)
 
     # Validate that the layer was added to the map
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)")
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -65,7 +66,7 @@ def test_add_image_collection_algorithm_multiple_filters(clean_qgis_iface):
     run_algorithm_with_params(params)
 
     # Validate that the layer was added to the map
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)")
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -117,7 +118,7 @@ def test_add_image_collection_algorithm_empty_filters(clean_qgis_iface):
     run_algorithm_with_params(params)
 
     # Validate that the layer was added to the map
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)")
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -143,7 +144,7 @@ def test_add_image_collection_algorithm_percentile_compositing(clean_qgis_iface)
     run_algorithm_with_params(params)
 
     # Validate that the layer was added to the map with the correct compositing method
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("IC: LANDSAT/LC09/C02/T1_L2 (Percentile 90%)")
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Percentile 90%)"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -193,7 +194,7 @@ def test_empty_viz_params(clean_qgis_iface):
     run_algorithm_with_params(params)
 
     # Validate that the layer was added to the map
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)")
     assert layer.name() == "IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)"
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"
@@ -232,7 +233,7 @@ def test_add_image_collection_with_varied_extent_crs(
     }
 
     run_algorithm_with_params(params)
-    layer = clean_qgis_iface.mapCanvas().layers()[0]
+    layer = get_layer_by_name("IC: LANDSAT/LC09/C02/T1_L2 (Mosaic)")
     assert layer.name().startswith("IC:")
     assert layer.customProperty("ee-layer")
     assert layer.customProperty("ee-layer-type") == "raster"

--- a/test/test_provider.py
+++ b/test/test_provider.py
@@ -1,13 +1,14 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import ee
 from qgis.core import QgsProject, QgsPointXY, QgsDataProvider, QgsRaster
 
 from ee_plugin import Map
 from ee_plugin.provider import EarthEngineRasterDataProvider
+from ee_plugin.utils import get_ee_image_url, get_ee_object_from_layer
 
 
-def test_raster_identify():
+def test_raster_layer_persists_ee_object():
     image = ee.Image("USGS/SRTMGL1_003")
     vis_params = {
         "min": 0,
@@ -24,9 +25,26 @@ def test_raster_identify():
         assert layer.crs().authid() == "EPSG:3857", (
             "Layer CRS does not match project CRS"
         )
+        assert layer.customProperty("ee-layer")
+        assert layer.customProperty("ee-layer-type") == "raster"
+        assert get_ee_object_from_layer(layer) is not None
 
-        provider = layer.dataProvider()
-        qgis_point = QgsPointXY(-13551778.88787266425788403, 5917193.28679858986288309)
+
+def test_provider_identify():
+    image = ee.Image("USGS/SRTMGL1_003")
+    provider = EarthEngineRasterDataProvider(
+        uri=f"type=xyz&url={get_ee_image_url(image.visualize())}",
+        providerOptions=QgsDataProvider.ProviderOptions(),
+        flags=None,
+        image=image,
+    )
+    provider.ee_info = {"bands": [{"crs": "EPSG:4326", "id": "elevation"}]}
+    provider.ee_object.reduceRegion = Mock(
+        return_value=Mock(getInfo=Mock(return_value={"elevation": 123}))
+    )
+
+    qgis_point = QgsPointXY(-13551778.88787266425788403, 5917193.28679858986288309)
+    with patch("ee_plugin.Map.getScale", return_value=30):
         raster_identify_result = provider.identify(
             qgis_point,
             format=QgsRaster.IdentifyFormat.IdentifyFormatValue,
@@ -35,16 +53,16 @@ def test_raster_identify():
             dpi=96,
         )
 
-        assert raster_identify_result, "Identify operation returned no results"
-        assert raster_identify_result.isValid(), (
-            "Identify operation returned an invalid result"
-        )
-        assert len(raster_identify_result.results()) == 1, (
-            "Identify returned more than one band"
-        )
-        assert raster_identify_result.results()[1] > 0, (
-            "Identified elevation is not positive"
-        )
+    assert raster_identify_result, "Identify operation returned no results"
+    assert raster_identify_result.isValid(), (
+        "Identify operation returned an invalid result"
+    )
+    assert len(raster_identify_result.results()) == 1, (
+        "Identify returned more than one band"
+    )
+    assert raster_identify_result.results()[1] > 0, (
+        "Identified elevation is not positive"
+    )
 
 
 def test_reduce_region():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,8 +1,13 @@
 import pytest
-from qgis.core import QgsRectangle
+from qgis.core import QgsProject, QgsRectangle, QgsVectorLayer
 
 import ee
-from ee_plugin.utils import get_ee_properties, get_available_bands, tile_extent
+from ee_plugin.utils import (
+    get_ee_properties,
+    get_available_bands,
+    get_layer_by_name,
+    tile_extent,
+)
 
 # Initialize Earth Engine
 ee.Initialize()
@@ -65,3 +70,21 @@ def test_tile_extent_coordinates_match_projection():
         tile_extent(
             img, extent_3857.toRectF().getCoords(), scale=30, projection="EPSG:4326"
         )
+
+
+def test_get_layer_by_name_returns_project_layer_not_on_canvas():
+    """get_layer_by_name should return a layer from the project even if it is not on the canvas."""
+    layer = QgsVectorLayer(
+        "Point?crs=EPSG:4326&field=name:string", "test_offcanvas", "memory"
+    )
+    assert layer.isValid()
+    QgsProject.instance().addMapLayer(layer, False)
+
+    try:
+        result = get_layer_by_name("test_offcanvas")
+        assert result is not None, (
+            "get_layer_by_name returned None for a project layer not on the canvas"
+        )
+        assert result.id() == layer.id()
+    finally:
+        QgsProject.instance().removeMapLayers([layer.id()])


### PR DESCRIPTION
Fixes the EE raster refresh/rendering issue by moving raster display to QGIS's built-in tiled provider and storing EE state in
layer custom properties.

Includes:
  - switch EE raster display off the custom raster provider
  - persist EE raster metadata on the layer
  - update export/reload logic to use stored EE metadata
  - update raster layers in place instead of replacing them
  - adjust tests and local `act` workflow support

Tracking the identify tool in: #441 

Closes: #318 