### PR TITLE
feat: Add __version__.py and update check_version to use GitHub raw URL

### DIFF
--- a/ee_plugin/__init__.py
+++ b/ee_plugin/__init__.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
+import configparser
 import os
 import site
 
-from .__version__ import __version__
+
+def _plugin_version() -> str:
+    cfg = configparser.ConfigParser()
+    cfg.read(os.path.join(os.path.dirname(__file__), "metadata.txt"))
+    try:
+        return cfg.get("general", "version")
+    except configparser.NoOptionError:
+        return "0.0.0-dev"
 
 
 def add_ee_dependencies():
@@ -29,7 +37,7 @@ def classFactory(iface):  # pylint: disable=invalid-name
     # set User Agent for all calls
     import ee
 
-    user_agent = f"QGIS_EE/{__version__}"
+    user_agent = f"QGIS_EE/{_plugin_version()}"
     if ee.data.getUserAgent() != user_agent:
         ee.data.setUserAgent(user_agent)
 

--- a/ee_plugin/__init__.py
+++ b/ee_plugin/__init__.py
@@ -2,7 +2,7 @@
 import os
 import site
 
-__version__ = "0.1.8"
+from .__version__ import __version__
 
 
 def add_ee_dependencies():

--- a/ee_plugin/__version__.py
+++ b/ee_plugin/__version__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+__version__ = "0.1.8"

--- a/ee_plugin/__version__.py
+++ b/ee_plugin/__version__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__version__ = "0.1.8"

--- a/ee_plugin/ee_plugin.py
+++ b/ee_plugin/ee_plugin.py
@@ -40,6 +40,11 @@ except configparser.NoOptionError:
 version_checked = False
 
 
+def _parse_version(version: str) -> tuple[int, ...]:
+    normalized = version.strip().lstrip("v")
+    return tuple(int(part) for part in normalized.split("."))
+
+
 def icon(icon_name: str) -> QIcon:
     """Helper function to return an icon from the plugin directory."""
     return QIcon(os.path.join(PLUGIN_DIR, "icons", icon_name))
@@ -253,25 +258,26 @@ class GoogleEarthEnginePlugin(object):
             return
 
         try:
-            import re
-
-            # Attempt to get the latest version from the server
+            # Compare against the latest published release tag, not main, so
+            # users are only prompted about versions that have actually shipped.
             response = requests.get(
-                "https://raw.githubusercontent.com/gee-community/qgis-earthengine-plugin/refs/heads/main/ee_plugin/__version__.py",
+                "https://api.github.com/repos/gee-community/qgis-earthengine-plugin/releases/latest",
                 # requires requests > 2.4, can through requests.exceptions.Timeout (which is a RequestException, so already handled)
                 timeout=10,
             )
-            match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", response.text)
-            if match:
-                latest_version = match.group(1)
-                if VERSION < latest_version:
-                    self.iface.messageBar().pushMessage(
-                        "Earth Engine plugin:",
-                        "There is a more recent version of the ee_plugin available {0} and you have {1}, please upgrade!".format(
-                            latest_version, VERSION
-                        ),
-                        duration=15,
-                    )
+            response.raise_for_status()
+
+            latest_version = response.json().get("tag_name", "").lstrip("v")
+            if latest_version and _parse_version(VERSION) < _parse_version(
+                latest_version
+            ):
+                self.iface.messageBar().pushMessage(
+                    "Earth Engine plugin:",
+                    "There is a more recent version of the ee_plugin available {0} and you have {1}, please upgrade!".format(
+                        latest_version, VERSION
+                    ),
+                    duration=15,
+                )
         except requests.RequestException as e:
             print(f"HTTP error occurred when checking for recent plugin version: {e}")
         except ValueError as e:

--- a/ee_plugin/ee_plugin.py
+++ b/ee_plugin/ee_plugin.py
@@ -253,21 +253,25 @@ class GoogleEarthEnginePlugin(object):
             return
 
         try:
+            import re
+
             # Attempt to get the latest version from the server
-            latest_version = requests.get(
-                "https://qgis-ee-plugin.appspot.com/get_latest_version",
+            response = requests.get(
+                "https://raw.githubusercontent.com/gee-community/qgis-earthengine-plugin/refs/heads/main/ee_plugin/__version__.py",
                 # requires requests > 2.4, can through requests.exceptions.Timeout (which is a RequestException, so already handled)
                 timeout=10,
-            ).text
-
-            if VERSION < latest_version:
-                self.iface.messageBar().pushMessage(
-                    "Earth Engine plugin:",
-                    "There is a more recent version of the ee_plugin available {0} and you have {1}, please upgrade!".format(
-                        latest_version, VERSION
-                    ),
-                    duration=15,
-                )
+            )
+            match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", response.text)
+            if match:
+                latest_version = match.group(1)
+                if VERSION < latest_version:
+                    self.iface.messageBar().pushMessage(
+                        "Earth Engine plugin:",
+                        "There is a more recent version of the ee_plugin available {0} and you have {1}, please upgrade!".format(
+                            latest_version, VERSION
+                        ),
+                        duration=15,
+                    )
         except requests.RequestException as e:
             print(f"HTTP error occurred when checking for recent plugin version: {e}")
         except ValueError as e:


### PR DESCRIPTION
This PR adds a separate `__version__.py` file to the plugin inside the `ee_plugin` directory, and updates the version checking mechanism in `ee_plugin.py` to query the latest version from raw GitHub content rather than the Appspot endpoint.