### PR TITLE
feat: vector visParams support and style

### DIFF
--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -4,6 +4,7 @@ Utils functions for EE
 """
 
 from qgis.PyQt.QtGui import QColor
+from qgis.PyQt.QtCore import Qt, QCoreApplication
 
 import os
 import math
@@ -11,6 +12,13 @@ import json
 import tempfile
 import logging
 from typing import Optional, TypedDict, Tuple, Any, List
+
+try:
+    import gzip
+
+    _GZIP_AVAILABLE = True
+except ImportError:
+    _GZIP_AVAILABLE = False
 
 import ee
 import qgis
@@ -26,8 +34,11 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsProcessingContext,
     QgsCoordinateTransform,
+    QgsWkbTypes,
+    QgsSimpleMarkerSymbolLayer,
+    QgsSimpleLineSymbolLayer,
+    QgsSimpleFillSymbolLayer,
 )
-from qgis.PyQt.QtCore import QCoreApplication
 
 
 logger = logging.getLogger(__name__)
@@ -249,9 +260,13 @@ def add_or_update_ee_layer(
                 eeObject, name, vis_params, shown, opacity
             )
         else:
-            layer = add_or_update_ee_vector_layer(eeObject, name, shown, opacity)
+            layer = add_or_update_ee_vector_layer(
+                eeObject, name, vis_params, shown, opacity
+            )
     elif isinstance(eeObject, ee.Geometry):
-        layer = add_or_update_ee_vector_layer(eeObject, name, shown, opacity)
+        layer = add_or_update_ee_vector_layer(
+            eeObject, name, vis_params, shown, opacity
+        )
     elif isinstance(eeObject, ee.ImageCollection):
         reduce_image = eeObject.reduce(ee.Reducer.median())
         layer = add_or_update_ee_raster_layer(reduce_image, name, vis_params, shown)
@@ -349,43 +364,273 @@ def add_or_update_named_vector_layer(
     table_id = eeObject.args.get("tableId", "")
     if not table_id:
         raise ValueError(f"FeatureCollection {name} does not have a valid tableId.")
-    image = ee.Image().paint(eeObject, 0, 2)
-    return add_or_update_ee_raster_layer(image, name, vis_params, shown, opacity)
+    vector_style_keys = {
+        "color",
+        "fillColor",
+        "width",
+        "pointSize",
+        "pointShape",
+        "lineType",
+    }
+    if vis_params and any(k in vis_params for k in vector_style_keys):
+        # Filter to only valid style() params to avoid passing unknown keys
+        valid_style_keys = {
+            "color",
+            "fillColor",
+            "width",
+            "pointSize",
+            "pointShape",
+            "lineType",
+        }
+        style_kwargs = {k: v for k, v in vis_params.items() if k in valid_style_keys}
+        image = eeObject.style(**style_kwargs)
+        # Style is already baked into the image; don't pass vis_params again
+        return add_or_update_ee_raster_layer(image, name, {}, shown, opacity)
+    else:
+        image = ee.Image().paint(eeObject, 0, 2)
+        return add_or_update_ee_raster_layer(image, name, vis_params, shown, opacity)
 
 
 def add_or_update_ee_vector_layer(
     eeObject: ee.Element,
     name: str,
+    vis_params: Optional[dict] = None,
     shown: bool = True,
     opacity: float = 1.0,
-    style_params: Optional[dict] = None,
 ) -> QgsVectorLayer:
     logger.debug(f"Adding/updating EE vector layer: {name}")
     layer = get_layer_by_name(name)
     if layer:
         if not layer.customProperty("ee-layer"):
             raise Exception(f"Layer is not an EE layer: {name}")
-        return update_ee_vector_layer(eeObject, layer, shown, opacity)
-    return add_ee_vector_layer(eeObject, name, shown, opacity, style_params)
+        return update_ee_vector_layer(eeObject, layer, vis_params, shown, opacity)
+    return add_ee_vector_layer(eeObject, name, vis_params, shown, opacity)
 
 
-def add_ee_vector_layer(
-    eeObject: ee.Element,
-    name: str,
-    shown: bool = True,
-    opacity: float = 1.0,
-    style_params: Optional[dict] = None,
-) -> QgsVectorLayer:
-    logger.debug(f"Adding EE vector layer: {name}")
+def _geometry_type(name: str):
+    geometry_type = getattr(QgsWkbTypes, "GeometryType", QgsWkbTypes)
+    return getattr(geometry_type, name)
+
+
+def _constant_style_value(style_params: dict, key: str):
+    value = style_params.get(key)
+    if isinstance(value, dict):
+        logger.warning(
+            f"Data-driven style property '{key}' is not supported for QGIS vector layers; ignoring."
+        )
+        return None
+    return value
+
+
+def _numeric_style_value(style_params: dict, key: str) -> Optional[float]:
+    value = _constant_style_value(style_params, key)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Invalid numeric value '{value}' for style property '{key}', ignoring."
+        )
+        return None
+
+
+def _convert_line_type(line_type: str) -> Qt.PenStyle:
+    if not isinstance(line_type, str):
+        logger.warning(f"Invalid line type '{line_type}', falling back to solid.")
+        return Qt.PenStyle.SolidLine
+    mapping = {
+        "solid": Qt.PenStyle.SolidLine,
+        "dashed": Qt.PenStyle.DashLine,
+        "dotted": Qt.PenStyle.DotLine,
+    }
+    return mapping.get(line_type.lower(), Qt.PenStyle.SolidLine)
+
+
+def _get_marker_shape(shape_name: str):
+    if not isinstance(shape_name, str):
+        logger.warning(f"Invalid point shape '{shape_name}', falling back to circle.")
+        shape_name = "circle"
+    name = shape_name.lower()
+    try:
+        shape_cls = QgsSimpleMarkerSymbolLayer.Shape
+        mapping = {
+            "circle": shape_cls.Circle,
+            "square": shape_cls.Square,
+            "diamond": shape_cls.Diamond,
+            "triangle": shape_cls.Triangle,
+            "triangle_up": shape_cls.Triangle,
+            "cross": shape_cls.Cross,
+            "plus": shape_cls.Cross2,
+            "pentagon": shape_cls.Pentagon,
+            "hexagon": shape_cls.Hexagon,
+            "star5": shape_cls.Star,
+            "star6": shape_cls.Star,
+            "pentagram": shape_cls.Star,
+            "hexagram": shape_cls.Star,
+        }
+        if name not in mapping:
+            logger.warning(
+                f"Unknown point shape '{shape_name}', falling back to circle. "
+                f"Known shapes: {list(mapping.keys())}"
+            )
+        return mapping.get(name, shape_cls.Circle)
+    except AttributeError:
+        mapping = {
+            "circle": QgsSimpleMarkerSymbolLayer.Circle,
+            "square": QgsSimpleMarkerSymbolLayer.Square,
+            "diamond": QgsSimpleMarkerSymbolLayer.Diamond,
+            "triangle": QgsSimpleMarkerSymbolLayer.Triangle,
+            "triangle_up": QgsSimpleMarkerSymbolLayer.Triangle,
+            "cross": QgsSimpleMarkerSymbolLayer.Cross,
+            "plus": QgsSimpleMarkerSymbolLayer.Cross2,
+            "pentagon": QgsSimpleMarkerSymbolLayer.Pentagon,
+            "hexagon": QgsSimpleMarkerSymbolLayer.Hexagon,
+            "star5": QgsSimpleMarkerSymbolLayer.Star,
+            "star6": QgsSimpleMarkerSymbolLayer.Star,
+            "pentagram": QgsSimpleMarkerSymbolLayer.Star,
+            "hexagram": QgsSimpleMarkerSymbolLayer.Star,
+        }
+        if name not in mapping:
+            logger.warning(
+                f"Unknown point shape '{shape_name}', falling back to circle. "
+                f"Known shapes: {list(mapping.keys())}"
+            )
+        return mapping.get(name, QgsSimpleMarkerSymbolLayer.Circle)
+
+
+def _qcolor(value) -> Optional[QColor]:
+    if not isinstance(value, str):
+        logger.warning(f"Invalid color value '{value}', ignoring.")
+        return None
+    color_value = value.strip()
+    if not color_value.startswith("#") and len(color_value) in (3, 6, 8):
+        try:
+            int(color_value, 16)
+            color_value = f"#{color_value}"
+        except ValueError:
+            pass
+    color = QColor(color_value)
+    if color.isValid():
+        return color
+    logger.warning(f"Invalid color value '{value}', ignoring.")
+    return None
+
+
+def _apply_vector_style(layer: QgsVectorLayer, style_params: dict) -> None:
+    renderer = layer.renderer()
+    if not renderer or not renderer.symbol():
+        return
+
+    symbol = renderer.symbol()
+    symbol_layer = symbol.symbolLayer(0)
+    if not symbol_layer:
+        return
+
+    geometry_type = layer.geometryType()
+
+    base_color = _constant_style_value(style_params, "color")
+    base_fill_color = _constant_style_value(style_params, "fillColor") or base_color
+
+    opacity = _numeric_style_value(style_params, "opacity")
+    if geometry_type == _geometry_type("PointGeometry"):
+        point_opacity = _numeric_style_value(style_params, "pointFillOpacity")
+        if point_opacity is not None:
+            opacity = point_opacity
+    elif geometry_type == _geometry_type("LineGeometry"):
+        line_opacity = _numeric_style_value(style_params, "lineOpacity")
+        if line_opacity is not None:
+            opacity = line_opacity
+    elif geometry_type == _geometry_type("PolygonGeometry"):
+        stroke_opacity = _numeric_style_value(style_params, "polygonStrokeOpacity")
+        fill_opacity = _numeric_style_value(style_params, "polygonFillOpacity")
+        if stroke_opacity is not None:
+            opacity = stroke_opacity
+        elif fill_opacity is not None:
+            opacity = fill_opacity
+
+    if opacity is not None:
+        symbol.setOpacity(opacity)
+
+    if geometry_type == _geometry_type("PointGeometry"):
+        fill_color = (
+            _constant_style_value(style_params, "pointFillColor") or base_fill_color
+        )
+        stroke_color = base_color
+        size = _numeric_style_value(style_params, "pointSize")
+        shape = _constant_style_value(style_params, "pointShape")
+        stroke_width = _numeric_style_value(style_params, "width")
+
+        if isinstance(symbol_layer, QgsSimpleMarkerSymbolLayer):
+            if fill_color:
+                color = _qcolor(fill_color)
+                if color:
+                    symbol_layer.setColor(color)
+            if stroke_color:
+                color = _qcolor(stroke_color)
+                if color:
+                    symbol_layer.setStrokeColor(color)
+            if stroke_width is not None:
+                symbol_layer.setStrokeWidth(stroke_width)
+            if size is not None:
+                symbol_layer.setSize(size)
+            if shape:
+                symbol_layer.setShape(_get_marker_shape(shape))
+
+    elif geometry_type == _geometry_type("LineGeometry"):
+        line_color = _constant_style_value(style_params, "lineColor") or base_color
+        line_width = _numeric_style_value(style_params, "lineWidth")
+        if line_width is None:
+            line_width = _numeric_style_value(style_params, "width")
+        line_type = _constant_style_value(style_params, "lineType")
+
+        if isinstance(symbol_layer, QgsSimpleLineSymbolLayer):
+            if line_color:
+                color = _qcolor(line_color)
+                if color:
+                    symbol_layer.setColor(color)
+            if line_width is not None:
+                symbol_layer.setWidth(line_width)
+            if line_type:
+                symbol_layer.setPenStyle(_convert_line_type(line_type))
+
+    elif geometry_type == _geometry_type("PolygonGeometry"):
+        stroke_color = (
+            _constant_style_value(style_params, "polygonStrokeColor") or base_color
+        )
+        fill_color = (
+            _constant_style_value(style_params, "polygonFillColor") or base_fill_color
+        )
+        stroke_width = _numeric_style_value(style_params, "polygonStrokeWidth")
+        if stroke_width is None:
+            stroke_width = _numeric_style_value(style_params, "width")
+        stroke_type = _constant_style_value(style_params, "polygonStrokeType")
+
+        if isinstance(symbol_layer, QgsSimpleFillSymbolLayer):
+            if stroke_color:
+                color = _qcolor(stroke_color)
+                if color:
+                    symbol_layer.setStrokeColor(color)
+            if fill_color:
+                color = _qcolor(fill_color)
+                if color:
+                    symbol_layer.setFillColor(color)
+            if stroke_width is not None:
+                symbol_layer.setStrokeWidth(stroke_width)
+            if stroke_type:
+                symbol_layer.setStrokeStyle(_convert_line_type(stroke_type))
+
+
+def _ee_object_to_geojson(eeObject: ee.Element) -> dict:
     info = eeObject.getInfo()
 
     if info["type"] == "FeatureCollection":
-        geojson = {
+        return {
             "type": "FeatureCollection",
             "features": info["features"],
         }
     elif info["type"] == "Feature":
-        geojson = {
+        return {
             "type": "FeatureCollection",
             "features": [info],
         }
@@ -397,23 +642,60 @@ def add_ee_vector_layer(
         "MultiLineString",
         "LinearRing",
     ):
-        geojson = {
+        return {
             "type": "FeatureCollection",
             "features": [{"type": "Feature", "geometry": info, "properties": {}}],
         }
     else:
         raise ValueError("Unsupported EE object type: " + info["type"])
 
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".geojson")
-    with open(temp_file.name, "w") as f:
-        json.dump(geojson, f)
 
-    uri = temp_file.name
+def _write_geojson_temp_file(geojson: dict) -> str:
+    # Use gzip by default; fall back to plain .geojson if unavailable
+    compress = _GZIP_AVAILABLE
+    suffix = ".geojson.gz" if compress else ".geojson"
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    temp_file.close()  # close the fd so we can reopen it
+    if compress:
+        with gzip.open(temp_file.name, "wt", encoding="utf-8") as f:
+            json.dump(geojson, f)
+    else:
+        with open(temp_file.name, "w") as f:
+            json.dump(geojson, f)
+    return temp_file.name
+
+
+def _cleanup_vector_source(layer: QgsMapLayer) -> None:
+    """Remove the temporary GeoJSON file backing a vector layer, if any."""
+    source = layer.customProperty("ee-vector-source")
+    if not source:
+        return
+    try:
+        os.remove(source)
+        logger.debug(f"Cleaned up old vector source: {source}")
+    except PermissionError:
+        logger.warning(f"Could not remove old vector source (file locked): {source}")
+    except OSError as e:
+        logger.warning(f"Could not remove old vector source: {source} — {e}")
+
+
+def add_ee_vector_layer(
+    eeObject: ee.Element,
+    name: str,
+    vis_params: Optional[dict] = None,
+    shown: bool = True,
+    opacity: float = 1.0,
+) -> QgsVectorLayer:
+    logger.debug(f"Adding EE vector layer: {name}")
+    geojson = _ee_object_to_geojson(eeObject)
+    uri = _write_geojson_temp_file(geojson)
     layer = QgsVectorLayer(uri, name, "ogr")
     assert layer.isValid(), f"Failed to load vector layer: {name}"
     set_ee_layer_properties(layer, eeObject, style_params or {}, layer_type="vector")
 
     QgsProject.instance().addMapLayer(layer)
+    layer.setCustomProperty("ee-layer", True)
+    layer.setCustomProperty("ee-vector-source", uri)
 
     if shown is not None:
         tree_layer = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
@@ -424,17 +706,12 @@ def add_ee_vector_layer(
                 "Layer not found in layer tree when trying to set visibility."
             )
 
-    if style_params:
-        symbol = layer.renderer().symbol()
-        symbol_layer = symbol.symbolLayer(0)
-        if style_params.get("opacity"):
-            symbol.setOpacity(style_params["opacity"])
-        if style_params.get("color"):
-            symbol_layer.setStrokeColor(QColor(style_params["color"]))
-        if style_params.get("width"):
-            symbol_layer.setStrokeWidth(style_params["width"])
-        if style_params.get("fillColor"):
-            symbol_layer.setFillColor(QColor(style_params["fillColor"]))
+    renderer = layer.renderer()
+    if renderer and renderer.symbol() and opacity is not None:
+        renderer.symbol().setOpacity(opacity)
+
+    if vis_params:
+        _apply_vector_style(layer, vis_params)
 
     return layer
 
@@ -442,19 +719,38 @@ def add_ee_vector_layer(
 def update_ee_vector_layer(
     eeObject: ee.Element,
     layer: QgsMapLayer,
-    shown: bool,
-    opacity: float,
+    vis_params: Optional[dict] = None,
+    shown: bool = True,
+    opacity: float = 1.0,
 ) -> QgsVectorLayer:
     logger.debug(f"Updating EE vector layer: {layer.name()}")
-    geojson = eeObject.getInfo()
-    uri = f"GeoJSON?crs=EPSG:4326&url={json.dumps(geojson)}"
+    geojson = _ee_object_to_geojson(eeObject)
+    uri = _write_geojson_temp_file(geojson)
 
     new_layer = QgsVectorLayer(uri, layer.name(), "ogr")
+    assert new_layer.isValid(), f"Failed to load vector layer: {layer.name()}"
+    old_source = layer.customProperty("ee-vector-source")
     QgsProject.instance().removeMapLayers([layer.id()])
+    if old_source:
+        try:
+            os.remove(old_source)
+            logger.debug(f"Cleaned up old vector source: {old_source}")
+        except PermissionError:
+            logger.warning(
+                f"Could not remove old vector source (file locked): {old_source}"
+            )
+        except OSError as e:
+            logger.warning(f"Could not remove old vector source: {old_source} — {e}")
     QgsProject.instance().addMapLayer(new_layer)
+    new_layer.setCustomProperty("ee-layer", True)
+    new_layer.setCustomProperty("ee-vector-source", uri)
 
-    if opacity is not None and new_layer.renderer():
-        new_layer.renderer().setOpacity(opacity)
+    renderer = new_layer.renderer()
+    if renderer and renderer.symbol() and opacity is not None:
+        renderer.symbol().setOpacity(opacity)
+
+    if vis_params:
+        _apply_vector_style(new_layer, vis_params)
 
     if shown is not None:
         QgsProject.instance().layerTreeRoot().findLayer(

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -367,7 +367,14 @@ def add_or_update_named_vector_layer(
     # Keys accepted by FeatureCollection.style() on the EE server side.
     # Client-side-only keys (lineColor, polygonFillColor, etc.) are silently
     # dropped here; they only take effect on the local vector path.
-    ee_style_keys = {"color", "fillColor", "width", "pointSize", "pointShape", "lineType"}
+    ee_style_keys = {
+        "color",
+        "fillColor",
+        "width",
+        "pointSize",
+        "pointShape",
+        "lineType",
+    }
     if vis_params and any(k in vis_params for k in ee_style_keys):
         style_kwargs = {k: v for k, v in vis_params.items() if k in ee_style_keys}
         image = eeObject.style(**style_kwargs)
@@ -608,6 +615,7 @@ def _apply_vector_style(layer: QgsVectorLayer, style_params: dict) -> None:
                 symbol_layer.setStrokeStyle(_convert_line_type(stroke_type))
 
     from qgis.utils import iface
+
     iface.layerTreeView().refreshLayerSymbology(layer.id())
 
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -364,25 +364,12 @@ def add_or_update_named_vector_layer(
     table_id = eeObject.args.get("tableId", "")
     if not table_id:
         raise ValueError(f"FeatureCollection {name} does not have a valid tableId.")
-    vector_style_keys = {
-        "color",
-        "fillColor",
-        "width",
-        "pointSize",
-        "pointShape",
-        "lineType",
-    }
-    if vis_params and any(k in vis_params for k in vector_style_keys):
-        # Filter to only valid style() params to avoid passing unknown keys
-        valid_style_keys = {
-            "color",
-            "fillColor",
-            "width",
-            "pointSize",
-            "pointShape",
-            "lineType",
-        }
-        style_kwargs = {k: v for k, v in vis_params.items() if k in valid_style_keys}
+    # Keys accepted by FeatureCollection.style() on the EE server side.
+    # Client-side-only keys (lineColor, polygonFillColor, etc.) are silently
+    # dropped here; they only take effect on the local vector path.
+    ee_style_keys = {"color", "fillColor", "width", "pointSize", "pointShape", "lineType"}
+    if vis_params and any(k in vis_params for k in ee_style_keys):
+        style_kwargs = {k: v for k, v in vis_params.items() if k in ee_style_keys}
         image = eeObject.style(**style_kwargs)
         # Style is already baked into the image; don't pass vis_params again
         return add_or_update_ee_raster_layer(image, name, {}, shown, opacity)
@@ -668,18 +655,16 @@ def _write_geojson_temp_file(geojson: dict) -> str:
     return temp_file.name
 
 
-def _cleanup_vector_source(layer: QgsMapLayer) -> None:
-    """Remove the temporary GeoJSON file backing a vector layer, if any."""
-    source = layer.customProperty("ee-vector-source")
-    if not source:
+def _cleanup_vector_source_path(path: Optional[str]) -> None:
+    if not path:
         return
     try:
-        os.remove(source)
-        logger.debug(f"Cleaned up old vector source: {source}")
+        os.remove(path)
+        logger.debug(f"Cleaned up old vector source: {path}")
     except PermissionError:
-        logger.warning(f"Could not remove old vector source (file locked): {source}")
+        logger.warning(f"Could not remove old vector source (file locked): {path}")
     except OSError as e:
-        logger.warning(f"Could not remove old vector source: {source} — {e}")
+        logger.warning(f"Could not remove old vector source: {path} — {e}")
 
 
 def add_ee_vector_layer(
@@ -730,37 +715,26 @@ def update_ee_vector_layer(
     geojson = _ee_object_to_geojson(eeObject)
     uri = _write_geojson_temp_file(geojson)
 
-    new_layer = QgsVectorLayer(uri, layer.name(), "ogr")
-    assert new_layer.isValid(), f"Failed to load vector layer: {layer.name()}"
     old_source = layer.customProperty("ee-vector-source")
-    QgsProject.instance().removeMapLayers([layer.id()])
-    if old_source:
-        try:
-            os.remove(old_source)
-            logger.debug(f"Cleaned up old vector source: {old_source}")
-        except PermissionError:
-            logger.warning(
-                f"Could not remove old vector source (file locked): {old_source}"
-            )
-        except OSError as e:
-            logger.warning(f"Could not remove old vector source: {old_source} — {e}")
-    QgsProject.instance().addMapLayer(new_layer)
-    new_layer.setCustomProperty("ee-layer", True)
-    new_layer.setCustomProperty("ee-vector-source", uri)
+    layer.setDataSource(uri, layer.name(), "ogr")
+    assert layer.isValid(), f"Failed to reload vector layer: {layer.name()}"
 
-    renderer = new_layer.renderer()
+    _cleanup_vector_source_path(old_source)
+    layer.setCustomProperty("ee-vector-source", uri)
+
+    renderer = layer.renderer()
     if renderer and renderer.symbol() and opacity is not None:
         renderer.symbol().setOpacity(opacity)
 
     if vis_params:
-        _apply_vector_style(new_layer, vis_params)
+        _apply_vector_style(layer, vis_params)
 
     if shown is not None:
-        QgsProject.instance().layerTreeRoot().findLayer(
-            new_layer.id()
-        ).setItemVisibilityChecked(shown)
+        tree_node = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
+        if tree_node:
+            tree_node.setItemVisibilityChecked(shown)
 
-    return new_layer
+    return layer
 
 
 def add_ee_catalog_image(

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -618,6 +618,7 @@ def _apply_vector_style(layer: QgsVectorLayer, style_params: dict) -> None:
 
     iface.layerTreeView().refreshLayerSymbology(layer.id())
 
+
 def _ee_object_to_geojson(eeObject: ee.Element) -> dict:
     info = eeObject.getInfo()
 

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -618,7 +618,6 @@ def _apply_vector_style(layer: QgsVectorLayer, style_params: dict) -> None:
 
     iface.layerTreeView().refreshLayerSymbology(layer.id())
 
-
 def _ee_object_to_geojson(eeObject: ee.Element) -> dict:
     info = eeObject.getInfo()
 
@@ -687,7 +686,7 @@ def add_ee_vector_layer(
     uri = _write_geojson_temp_file(geojson)
     layer = QgsVectorLayer(uri, name, "ogr")
     assert layer.isValid(), f"Failed to load vector layer: {name}"
-    set_ee_layer_properties(layer, eeObject, style_params or {}, layer_type="vector")
+    set_ee_layer_properties(layer, eeObject, vis_params or {}, layer_type="vector")
 
     QgsProject.instance().addMapLayer(layer)
     layer.setCustomProperty("ee-layer", True)
@@ -722,14 +721,13 @@ def update_ee_vector_layer(
     logger.debug(f"Updating EE vector layer: {layer.name()}")
     geojson = _ee_object_to_geojson(eeObject)
     uri = _write_geojson_temp_file(geojson)
-
     old_source = layer.customProperty("ee-vector-source")
     layer.setDataSource(uri, layer.name(), "ogr")
     assert layer.isValid(), f"Failed to reload vector layer: {layer.name()}"
 
     _cleanup_vector_source_path(old_source)
+    set_ee_layer_properties(layer, eeObject, vis_params or {}, layer_type="vector")
     layer.setCustomProperty("ee-vector-source", uri)
-
     renderer = layer.renderer()
     if renderer and renderer.symbol() and opacity is not None:
         renderer.symbol().setOpacity(opacity)

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -382,7 +382,7 @@ def add_or_update_named_vector_layer(
         return add_or_update_ee_raster_layer(image, name, {}, shown, opacity)
     else:
         image = ee.Image().paint(eeObject, 0, 2)
-        return add_or_update_ee_raster_layer(image, name, vis_params, shown, opacity)
+        return add_or_update_ee_raster_layer(image, name, {}, shown, opacity)
 
 
 def add_or_update_ee_vector_layer(

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -620,6 +620,9 @@ def _apply_vector_style(layer: QgsVectorLayer, style_params: dict) -> None:
             if stroke_type:
                 symbol_layer.setStrokeStyle(_convert_line_type(stroke_type))
 
+    from qgis.utils import iface
+    iface.layerTreeView().refreshLayerSymbology(layer.id())
+
 
 def _ee_object_to_geojson(eeObject: ee.Element) -> dict:
     info = eeObject.getInfo()

--- a/examples/map_add_features.py
+++ b/examples/map_add_features.py
@@ -2,15 +2,39 @@ import ee
 
 from ee_plugin import Map
 
+# ── How style keys are applied ────────────────────────────────────────────────
+# The plugin uses two different rendering paths depending on the object type,
+# and each path supports a different set of style keys:
+#
+# LOCAL VECTOR PATH  — used for ee.Geometry objects, and for FeatureCollections
+#   that have been filtered or transformed (e.g. .filter(), .filterBounds()).
+#   The data is fetched once from EE and stored as a local GeoJSON layer in
+#   QGIS. All client-side style keys are supported:
+#     color, fillColor, width, opacity,
+#     pointFillColor, pointFillOpacity, pointSize, pointShape,
+#     lineColor, lineWidth, lineOpacity, lineType,
+#     polygonStrokeColor, polygonStrokeWidth, polygonFillColor,
+#     polygonFillOpacity, polygonStrokeType
+#
+# CATALOG TILE PATH  — used for a bare FeatureCollection loaded directly by
+#   asset ID without any further EE operations (e.g.
+#   ee.FeatureCollection("USDOS/LSIB_SIMPLE/2017")).
+#   The collection is rendered server-side as an XYZ tile using
+#   FeatureCollection.style(). Only the keys that .style() accepts work here:
+#     color, fillColor, width, pointSize, pointShape, lineType
+#   All other keys above are silently ignored on this path.
+#   For anything beyond those six keys, call .style() yourself (see Example 7).
+# ─────────────────────────────────────────────────────────────────────────────
+
 # ── Example 1: Single feature (polygon) with basic color ──
-# The "color" key sets the stroke color for polygon boundaries.
+# "color" sets both stroke and fill on the local vector path.
+# It also works on the catalog tile path (it is a .style() key).
 countries = ee.FeatureCollection("USDOS/LSIB_SIMPLE/2017")
 country = countries.filter(ee.Filter.eq("country_na", "Ukraine"))
 Map.addLayer(country, {"color": "orange"}, "feature_basic_color")
 
 # ── Example 2: Polygon with fill and stroke ──
-# "fillColor" controls interior color; "color" is the outline.
-# "width" sets the outline width in pixels.
+# "fillColor" and "width" work on both paths.
 Map.addLayer(
     country,
     {
@@ -22,7 +46,9 @@ Map.addLayer(
 )
 
 # ── Example 3: Polygon with opacity ──
-# "opacity" (0-1) controls both fill and stroke transparency.
+# "opacity" is a local vector path key only — it has no equivalent in
+# FeatureCollection.style(). Works here because .filter() puts the collection
+# on the local vector path.
 Map.addLayer(
     country,
     {
@@ -35,9 +61,10 @@ Map.addLayer(
 )
 
 # ── Example 4: Point features with shape and size ──
-# "pointShape" can be "circle", "square", "triangle", "diamond", etc.
-# "pointSize" controls the diameter in pixels.
-# "pointFillColor" and "pointFillOpacity" set the interior styling.
+# .filter() puts cities on the local vector path, so all point-specific keys
+# are available. "pointShape", "pointFillColor", "pointFillOpacity" are
+# local-vector-only keys — they would be ignored on the catalog tile path.
+# "pointSize", "color", and "width" also work on the catalog tile path.
 cities = ee.FeatureCollection("FAO/GAUL/2015/level2").filter(
     ee.Filter.eq("ADM0_NAME", "Colombia")
 )
@@ -55,8 +82,9 @@ Map.addLayer(
 )
 
 # ── Example 5: Line features with dash patterns ──
-# "lineType" accepts "solid", "dashed", or "dotted".
-# "lineWidth" and "lineColor" control the stroke appearance.
+# .filterBounds() and .filter() put some_rivers on the local vector path.
+# "lineColor", "lineWidth", "lineOpacity" are local-vector-only keys.
+# "lineType" also works on the catalog tile path.
 rivers = ee.FeatureCollection("WWF/HydroSHEDS/v1/FreeFlowingRivers")
 roi = ee.Geometry.Rectangle([-76, 2, -74, 6])
 some_rivers = rivers.filterBounds(roi).filter(ee.Filter.lte("RIV_ORD", 5))
@@ -71,9 +99,10 @@ Map.addLayer(
     "rivers_dashed",
 )
 
-# ── Example 6: Polygon with separate stroke and fill opacity ──
-# "polygonStrokeWidth", "polygonStrokeColor", "polygonFillColor", etc.
-# allow fine-grained control of polygon appearance.
+# ── Example 6: Polygon geometry-specific keys ──
+# These fine-grained polygon keys are local-vector-only — they are not
+# accepted by FeatureCollection.style() and would be silently ignored on
+# the catalog tile path.
 Map.addLayer(
     country,
     {
@@ -85,10 +114,11 @@ Map.addLayer(
     "feature_polygon_specific",
 )
 
-# ── Example 7: Using GEE .style() for data-driven visuals ──
-# When a FeatureCollection has many features, call .style() on the
-# server side and pass an empty visParams dict so the baked-in
-# style is rendered directly in QGIS.
+# ── Example 7: Catalog FeatureCollection with server-side .style() ──
+# A bare FeatureCollection loaded by asset ID (no filter or transform) goes
+# through the catalog tile path and only accepts the six .style() keys.
+# For any styling beyond those, call .style() on the server side yourself.
+# The result of .style() is an ee.Image, so pass {} as vis_params.
 styled_fc = countries.filter(ee.Filter.eq("country_na", "Germany")).style(
     **{"fillColor": "gold", "color": "darkgoldenrod", "width": 2}
 )

--- a/examples/map_add_features.py
+++ b/examples/map_add_features.py
@@ -2,12 +2,97 @@ import ee
 
 from ee_plugin import Map
 
-# get a single feature
+# ── Example 1: Single feature (polygon) with basic color ──
+# The "color" key sets the stroke color for polygon boundaries.
 countries = ee.FeatureCollection("USDOS/LSIB_SIMPLE/2017")
 country = countries.filter(ee.Filter.eq("country_na", "Ukraine"))
+Map.addLayer(country, {"color": "orange"}, "feature_basic_color")
 
-# TEST: add feature to the Map
-Map.addLayer(country, {"color": "orange"}, "feature")
+# ── Example 2: Polygon with fill and stroke ──
+# "fillColor" controls interior color; "color" is the outline.
+# "width" sets the outline width in pixels.
+Map.addLayer(
+    country,
+    {
+        "fillColor": "lightblue",
+        "color": "darkblue",
+        "width": 3,
+    },
+    "feature_fill_stroke",
+)
 
-# set Map center using coordinates and zoom
+# ── Example 3: Polygon with opacity ──
+# "opacity" (0-1) controls both fill and stroke transparency.
+Map.addLayer(
+    country,
+    {
+        "fillColor": "green",
+        "color": "darkgreen",
+        "opacity": 0.4,
+        "width": 2,
+    },
+    "feature_opacity",
+)
+
+# ── Example 4: Point features with shape and size ──
+# "pointShape" can be "circle", "square", "triangle", "diamond", etc.
+# "pointSize" controls the diameter in pixels.
+# "pointFillColor" and "pointFillOpacity" set the interior styling.
+cities = ee.FeatureCollection("FAO/GAUL/2015/level2").filter(
+    ee.Filter.eq("ADM0_NAME", "Colombia")
+)
+Map.addLayer(
+    cities,
+    {
+        "pointShape": "diamond",
+        "pointSize": 10,
+        "pointFillColor": "red",
+        "pointFillOpacity": 0.8,
+        "color": "darkred",
+        "width": 2,
+    },
+    "points_styled",
+)
+
+# ── Example 5: Line features with dash patterns ──
+# "lineType" accepts "solid", "dashed", or "dotted".
+# "lineWidth" and "lineColor" control the stroke appearance.
+rivers = ee.FeatureCollection("WWF/HydroSHEDS/v1/FreeFlowingRivers")
+roi = ee.Geometry.Rectangle([-76, 2, -74, 6])
+some_rivers = rivers.filterBounds(roi).filter(ee.Filter.lte("RIV_ORD", 5))
+Map.addLayer(
+    some_rivers,
+    {
+        "lineType": "dashed",
+        "lineWidth": 1,
+        "lineColor": "blue",
+        "lineOpacity": 0.7,
+    },
+    "rivers_dashed",
+)
+
+# ── Example 6: Polygon with separate stroke and fill opacity ──
+# "polygonStrokeWidth", "polygonStrokeColor", "polygonFillColor", etc.
+# allow fine-grained control of polygon appearance.
+Map.addLayer(
+    country,
+    {
+        "polygonStrokeWidth": 4,
+        "polygonStrokeColor": "purple",
+        "polygonFillColor": "lavender",
+        "polygonFillOpacity": 0.3,
+    },
+    "feature_polygon_specific",
+)
+
+# ── Example 7: Using GEE .style() for data-driven visuals ──
+# When a FeatureCollection has many features, call .style() on the
+# server side and pass an empty visParams dict so the baked-in
+# style is rendered directly in QGIS.
+styled_fc = countries.filter(ee.Filter.eq("country_na", "Germany")).style(
+    **{"fillColor": "gold", "color": "darkgoldenrod", "width": 2}
+)
+Map.addLayer(styled_fc, {}, "feature_gee_styled")
+
+# ── Set Map center using coordinates and zoom ──
 Map.setCenter(31.472, 49.044, 6)

--- a/test/test_vector.py
+++ b/test/test_vector.py
@@ -1,12 +1,30 @@
 import ee
 import pytest
-from qgis.core import QgsMapLayer, QgsProject
+from qgis.PyQt.QtGui import QColor
+from qgis.core import QgsMapLayer, QgsProject, QgsWkbTypes
 
 from ee_plugin import Map
 
 # initialize the Earth Engine API is required to use the ee.Geometry module
 #   and runs before fixtures
 ee.Initialize()
+
+
+def qgis_geometry_type(name):
+    geometry_enum = getattr(QgsWkbTypes, "GeometryType", QgsWkbTypes)
+    return getattr(geometry_enum, name)
+
+
+def expected_qcolor(value):
+    color_value = value.strip()
+    if not color_value.startswith("#") and len(color_value) in (3, 6, 8):
+        try:
+            int(color_value, 16)
+            color_value = f"#{color_value}"
+        except ValueError:
+            pass
+    return QColor(color_value)
+
 
 geometries = [
     (ee.Geometry.Point([1.5, 1.5]), {"color": "1eff05"}, "point"),
@@ -54,6 +72,161 @@ def test_add_geometry_layer(geometry, vis_params, layer_name):
     assert layer.type() == QgsMapLayer.LayerType.VectorLayer, (
         "Layer is not a vector layer"
     )
+
+    if "color" in vis_params:
+        renderer = layer.renderer()
+        if not renderer or not renderer.symbol():
+            pytest.skip("QGIS/OGR loaded this geometry without a renderable symbol")
+        symbol = renderer.symbol()
+        symbol_layer = symbol.symbolLayer(0)
+        expected_color = expected_qcolor(vis_params["color"])
+        geometry_type = layer.geometryType()
+
+        if geometry_type == qgis_geometry_type("PointGeometry"):
+            assert symbol_layer.color() == expected_color, (
+                f"Expected point fill {expected_color.name()}, "
+                f"got {symbol_layer.color().name()}"
+            )
+            assert symbol_layer.strokeColor() == expected_color, (
+                f"Expected point stroke {expected_color.name()}, "
+                f"got {symbol_layer.strokeColor().name()}"
+            )
+        elif geometry_type == qgis_geometry_type("LineGeometry"):
+            assert symbol_layer.color() == expected_color, (
+                f"Expected line color {expected_color.name()}, "
+                f"got {symbol_layer.color().name()}"
+            )
+        elif geometry_type == qgis_geometry_type("PolygonGeometry"):
+            assert symbol_layer.strokeColor() == expected_color, (
+                f"Expected polygon stroke {expected_color.name()}, "
+                f"got {symbol_layer.strokeColor().name()}"
+            )
+            assert symbol_layer.fillColor() == expected_color, (
+                f"Expected polygon fill {expected_color.name()}, "
+                f"got {symbol_layer.fillColor().name()}"
+            )
+
+
+def test_geometry_fill_color_override():
+    qgis_instance = QgsProject.instance()
+    polygon = ee.Geometry.Polygon([[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]])
+    Map.addLayer(polygon, {"color": "red", "fillColor": "blue"}, "fill_override")
+
+    layers = qgis_instance.mapLayersByName("fill_override")
+    assert len(layers) == 1
+    layer = layers[0]
+    symbol_layer = layer.renderer().symbol().symbolLayer(0)
+
+    assert symbol_layer.strokeColor() == expected_qcolor("red")
+    assert symbol_layer.fillColor() == expected_qcolor("blue")
+
+
+def test_line_geometry_specific_override():
+    qgis_instance = QgsProject.instance()
+    line = ee.Geometry.LineString([[0, 0], [10, 10]])
+    Map.addLayer(line, {"color": "red", "lineColor": "green"}, "line_override")
+
+    layers = qgis_instance.mapLayersByName("line_override")
+    assert len(layers) == 1
+    layer = layers[0]
+    symbol_layer = layer.renderer().symbol().symbolLayer(0)
+
+    assert symbol_layer.color() == expected_qcolor("green")
+
+
+def test_geometry_width_property():
+    qgis_instance = QgsProject.instance()
+    polygon = ee.Geometry.Rectangle([0, 0, 10, 10])
+    Map.addLayer(polygon, {"color": "black", "width": 5}, "width_test")
+
+    layers = qgis_instance.mapLayersByName("width_test")
+    assert len(layers) == 1
+    layer = layers[0]
+    symbol_layer = layer.renderer().symbol().symbolLayer(0)
+
+    assert symbol_layer.strokeWidth() == 5
+
+
+def test_filtered_feature_collection_with_color():
+    qgis_instance = QgsProject.instance()
+    countries = ee.FeatureCollection("USDOS/LSIB_SIMPLE/2017")
+    ukraine = countries.filter(ee.Filter.eq("country_na", "Ukraine"))
+
+    Map.addLayer(ukraine, {"color": "orange"}, "ukraine_test")
+
+    layers = qgis_instance.mapLayersByName("ukraine_test")
+    assert len(layers) == 1, "Wrong number of layers added"
+    layer = layers[0]
+    assert layer.name() == "ukraine_test", "Layer name mismatch"
+
+
+def test_line_type_mapping():
+    """Verify GEE lineType values map correctly to QGIS pen styles."""
+    from qgis.PyQt.QtCore import Qt
+
+    qgis_instance = QgsProject.instance()
+    line = ee.Geometry.LineString([[0, 0], [10, 10]])
+
+    # Test "dashed" (official GEE value)
+    Map.addLayer(line, {"lineColor": "blue", "lineType": "dashed"}, "line_dashed")
+    layer = qgis_instance.mapLayersByName("line_dashed")[0]
+    symbol_layer = layer.renderer().symbol().symbolLayer(0)
+    assert symbol_layer.penStyle() == Qt.PenStyle.DashLine
+
+    # Test "dotted" (official GEE value)
+    Map.addLayer(line, {"lineColor": "blue", "lineType": "dotted"}, "line_dotted")
+    layer = qgis_instance.mapLayersByName("line_dotted")[0]
+    symbol_layer = layer.renderer().symbol().symbolLayer(0)
+    assert symbol_layer.penStyle() == Qt.PenStyle.DotLine
+
+
+def test_polygon_stroke_type_mapping():
+    """Verify GEE polygonStrokeType values map correctly to QGIS stroke styles."""
+    from qgis.PyQt.QtCore import Qt
+
+    qgis_instance = QgsProject.instance()
+    polygon = ee.Geometry.Polygon([[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]])
+
+    # Test "dashed" for polygon stroke
+    Map.addLayer(
+        polygon,
+        {"polygonStrokeColor": "red", "polygonStrokeType": "dashed"},
+        "polygon_dashed",
+    )
+    layer = qgis_instance.mapLayersByName("polygon_dashed")[0]
+    symbol_layer = layer.renderer().symbol().symbolLayer(0)
+    assert symbol_layer.strokeStyle() == Qt.PenStyle.DashLine
+
+    # Test "dotted" for polygon stroke
+    Map.addLayer(
+        polygon,
+        {"polygonStrokeColor": "red", "polygonStrokeType": "dotted"},
+        "polygon_dotted",
+    )
+    layer = qgis_instance.mapLayersByName("polygon_dotted")[0]
+    symbol_layer = layer.renderer().symbol().symbolLayer(0)
+    assert symbol_layer.strokeStyle() == Qt.PenStyle.DotLine
+
+
+def test_vector_update_normalizes_geometry_types():
+    """Raw EE Geometry objects must be normalized to FeatureCollection on update."""
+    qgis_instance = QgsProject.instance()
+    point = ee.Geometry.Point([1.5, 1.5])
+
+    # First add
+    Map.addLayer(point, {"color": "red"}, "geom_normalize_test")
+    layers = qgis_instance.mapLayersByName("geom_normalize_test")
+    assert len(layers) == 1
+    assert layers[0].isValid(), "Initial Point layer must be valid"
+
+    # Update
+    Map.addLayer(point, {"color": "blue"}, "geom_normalize_test")
+    layers = qgis_instance.mapLayersByName("geom_normalize_test")
+    assert len(layers) == 1, "Update must not duplicate"
+    assert layers[0].isValid(), "Updated Point layer must be valid"
+    assert layers[0].customProperty("ee-layer") is True
+    source = layers[0].source()
+    assert source.endswith(".geojson") or source.endswith(".geojson.gz")
 
 
 def test_data_catalog_vector_layer():


### PR DESCRIPTION
`visParams` were not implemented for `FeatureCollection` vector layers. Even simple examples like the following were displayed with a random/default color:

```python
import ee
from ee_plugin import Map
countries = ee.FeatureCollection("USDOS/LSIB_SIMPLE/2017")
country = countries.filter(ee.Filter.eq("country_na", "Ukraine"))
Map.addLayer(country, {"color": "orange"}, "feature_basic_color")
```

Previously, the feature was displayed with a random color. This PR implements styling support for `FeatureCollection` vector layers using GEE FeatureView-style `visParams`, including color, fill, stroke, opacity, width, and point/polygon/line styles.

Reference: https://developers.google.com/earth-engine/guides/featureview_styling

This PR only implements styling, not full FeatureView support; see #446.

Full GEE FeatureView support still needs to be implemented separately because it requires a different approach. The current `FeatureCollection` (vector) implementation downloads the vector data to a local GeoJSON file, which is very limited compared to Earth Engine’s optimized FeatureView tile rendering.