### PR TITLE
fix: respect model intermediate EE layers

### DIFF
--- a/ee_plugin/processing/add_ee_image.py
+++ b/ee_plugin/processing/add_ee_image.py
@@ -28,11 +28,10 @@ from qgis.core import (
     QgsProcessingUtils,
 )
 
-from ..Map import addLayer
 from .. import Map
 from ..logging import local_context
 from ..ui.widgets import VisualizationParamsWidget
-from ..utils import get_available_bands, get_ee_extent
+from ..utils import add_processing_ee_layer, get_available_bands, get_ee_extent
 from ..ui.utils import serialize_color_ramp
 from .custom_algorithm_dialog import BaseAlgorithmDialog
 
@@ -119,6 +118,7 @@ class AddImageAlgorithmDialog(BaseAlgorithmDialog):
                 "EXTENT": self.extent_group.outputExtent(),
                 "EXTENT_CRS": self.extent_group.outputCrs(),
                 "CLIP_TO_EXTENT": self.clip_checkbox.isChecked(),
+                "LOAD_OUTPUT_LAYER": True,
             }
         except Exception as e:
             raise ValueError(f"Invalid parameters: {e}")
@@ -221,7 +221,9 @@ class AddEEImageAlgorithm(QgsProcessingAlgorithm):
             else:
                 viz_params = {}
 
-            layer = addLayer(ee_object, viz_params, image_id)
+            layer = add_processing_ee_layer(
+                ee_object, viz_params, image_id, context, parameters
+            )
 
             if not layer:
                 raise QgsProcessingException("Failed to add EE layer to map.")

--- a/ee_plugin/processing/add_feature_collection.py
+++ b/ee_plugin/processing/add_feature_collection.py
@@ -26,7 +26,13 @@ from qgis.PyQt.QtGui import QColor
 from .. import Map
 from ..ui.widgets import FilterWidget
 from ..processing.custom_algorithm_dialog import BaseAlgorithmDialog
-from ..utils import translate as _, get_ee_properties, filter_functions, get_ee_extent
+from ..utils import (
+    translate as _,
+    get_ee_properties,
+    filter_functions,
+    get_ee_extent,
+    add_processing_ee_layer,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -236,7 +242,7 @@ class AddFeatureCollectionAlgorithm(QgsProcessingAlgorithm):
             color=viz_color_hex, fillColor=viz_fill_color, width=int(viz_width)
         )
         # opacity can't be set from EE, we must apply in QGIS
-        layer = Map.addLayer(styled_fc, {}, layer_name)
+        layer = add_processing_ee_layer(styled_fc, {}, layer_name, context, parameters)
         if opacity != "":
             layer.setOpacity(int(opacity) / 100)
         result["OUTPUT_RASTER"] = layer
@@ -431,6 +437,7 @@ class AddFeatureCollectionAlgorithmDialog(BaseAlgorithmDialog):
             "viz_color_hex": self.outline_color.color().name(),
             "viz_fill_color": self.fill_color.color().name(),
             "viz_width": str(self.line_width.value()),
+            "LOAD_OUTPUT_LAYER": True,
         }
 
     def _on_fc_id_changed(self):

--- a/ee_plugin/processing/add_image_collection.py
+++ b/ee_plugin/processing/add_image_collection.py
@@ -43,6 +43,7 @@ from ..utils import (
     get_ee_extent,
     parse_extent_string,
     normalize_crs,
+    add_processing_ee_layer,
 )
 from ..ui.utils import serialize_color_ramp
 
@@ -300,6 +301,7 @@ class AddImageCollectionAlgorithmDialog(BaseAlgorithmDialog):
                 "percentile_value": self.percentile_value.value(),
                 "viz_params": viz_params,
                 "clip_to_extent": self.clip_checkbox.isChecked(),
+                "LOAD_OUTPUT_LAYER": True,
             }
             return params
 
@@ -596,6 +598,6 @@ class AddImageCollectionAlgorithm(QgsProcessingAlgorithm):
         if clip_to_extent and ee_extent:
             ic = ic.clip(ee_extent)
 
-        layer = Map.addLayer(ic, viz_params, name)
+        layer = add_processing_ee_layer(ic, viz_params, name, context, parameters)
 
         return {"OUTPUT": layer, "LAYER_NAME": layer.name()}

--- a/ee_plugin/processing/export_geotiff.py
+++ b/ee_plugin/processing/export_geotiff.py
@@ -42,12 +42,32 @@ from ..utils import (
     ee_image_to_geotiff,
     get_ee_object_from_layer,
     get_ee_raster_layers,
-    get_layer_by_name,
     is_ee_raster_layer,
 )
 
 
 logging = logging.getLogger(__name__)
+
+
+def _resolve_ee_raster_layer(identifier, context: QgsProcessingContext):
+    if identifier is None:
+        return None
+    if hasattr(identifier, "customProperty") and is_ee_raster_layer(identifier):
+        return identifier
+
+    try:
+        layer = context.getMapLayer(str(identifier))
+        if layer and is_ee_raster_layer(layer):
+            return layer
+    except Exception as exc:
+        logging.debug(
+            "Unable to resolve EE layer from processing context.", exc_info=exc
+        )
+
+    for layer in get_ee_raster_layers():
+        if identifier in (layer.id(), layer.name(), layer.source()):
+            return layer
+    return None
 
 
 class ExportGeoTIFFAlgorithmDialog(BaseAlgorithmDialog):
@@ -314,8 +334,21 @@ class ExportGeoTIFFAlgorithm(QgsProcessingAlgorithm):
         # add logs to algorithm dialog
         local_context.set_feedback(feedback)
         feedback.pushInfo("Validating parameters…")
-        selected_index = self.parameterAsEnum(parameters, "EE_IMAGE", context)
-        ee_img = self.raster_layers[selected_index]
+        ee_img = parameters.get("EE_IMAGE")
+        layer = _resolve_ee_raster_layer(ee_img, context)
+        if layer:
+            ee_img = layer.name()
+        elif isinstance(ee_img, int):
+            selected_index = self.parameterAsEnum(parameters, "EE_IMAGE", context)
+            ee_img = self.raster_layers[selected_index]
+        else:
+            ee_img = self.parameterAsString(parameters, "EE_IMAGE", context)
+            if (
+                isinstance(ee_img, str)
+                and ee_img.isdigit()
+                and int(ee_img) < len(self.raster_layers)
+            ):
+                ee_img = self.raster_layers[int(ee_img)]
         rect = self.parameterAsExtent(parameters, "EXTENT", context)
         rect_source_crs = self.parameterAsExtentCrs(parameters, "EXTENT", context)
         if (
@@ -343,7 +376,7 @@ class ExportGeoTIFFAlgorithm(QgsProcessingAlgorithm):
         if feedback.isCanceled():
             raise RuntimeError("Canceled")
 
-        layer = get_layer_by_name(ee_img)
+        layer = layer or _resolve_ee_raster_layer(ee_img, context)
 
         if not layer or not is_ee_raster_layer(layer):
             msg = f"Layer {ee_img} not found"

--- a/ee_plugin/utils.py
+++ b/ee_plugin/utils.py
@@ -248,28 +248,37 @@ def add_or_update_ee_layer(
     name: str,
     shown: bool,
     opacity: float,
+    add_to_project: bool = True,
+    context: Optional[QgsProcessingContext] = None,
 ) -> QgsMapLayer:
     logger.info(f"Adding/updating EE layer: {name}")
     if isinstance(eeObject, ee.Image):
         layer = add_or_update_ee_raster_layer(
-            eeObject, name, vis_params, shown, opacity
+            eeObject, name, vis_params, shown, opacity, add_to_project, context
         )
     elif isinstance(eeObject, ee.FeatureCollection):
         if is_named_dataset(eeObject):
             layer = add_or_update_named_vector_layer(
-                eeObject, name, vis_params, shown, opacity
+                eeObject, name, vis_params, shown, opacity, add_to_project, context
             )
         else:
             layer = add_or_update_ee_vector_layer(
-                eeObject, name, vis_params, shown, opacity
+                eeObject, name, vis_params, shown, opacity, add_to_project, context
             )
     elif isinstance(eeObject, ee.Geometry):
         layer = add_or_update_ee_vector_layer(
-            eeObject, name, vis_params, shown, opacity
+            eeObject, name, vis_params, shown, opacity, add_to_project, context
         )
     elif isinstance(eeObject, ee.ImageCollection):
         reduce_image = eeObject.reduce(ee.Reducer.median())
-        layer = add_or_update_ee_raster_layer(reduce_image, name, vis_params, shown)
+        layer = add_or_update_ee_raster_layer(
+            reduce_image,
+            name,
+            vis_params,
+            shown,
+            add_to_project=add_to_project,
+            context=context,
+        )
     else:
         raise TypeError("Unsupported EE object type")
 
@@ -292,18 +301,97 @@ def add_or_update_ee_layer(
     return layer
 
 
+def _store_created_layer(
+    layer: QgsMapLayer,
+    add_to_project: bool,
+    context: Optional[QgsProcessingContext] = None,
+) -> None:
+    if add_to_project:
+        QgsProject.instance().addMapLayer(layer)
+        return
+    if context is None:
+        raise RuntimeError("A processing context is required for temporary EE layers.")
+    context.temporaryLayerStore().addMapLayer(layer)
+
+
+def _optional_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        value = value.strip().lower()
+        if value in ("1", "true", "t", "yes", "y", "on"):
+            return True
+        if value in ("0", "false", "f", "no", "n", "off"):
+            return False
+    return None
+
+
+def _processing_context_looks_like_model_child(context: QgsProcessingContext) -> bool:
+    try:
+        expression_context = context.expressionContext()
+        for name in expression_context.variableNames():
+            if str(name).startswith("model_"):
+                return True
+    except Exception as exc:
+        logger.debug("Unable to inspect processing expression context.", exc_info=exc)
+
+    return False
+
+
+def processing_output_should_load(
+    parameters: Optional[dict],
+    context: QgsProcessingContext,
+    default: bool = True,
+) -> bool:
+    explicit = _optional_bool((parameters or {}).get("LOAD_OUTPUT_LAYER"))
+    if explicit is not None:
+        return explicit
+    if _processing_context_looks_like_model_child(context):
+        return False
+    return default
+
+
+def add_processing_ee_layer(
+    eeObject: ee.Element,
+    vis_params: VisualizeParams,
+    name: str,
+    context: QgsProcessingContext,
+    parameters: Optional[dict] = None,
+    shown: bool = True,
+    opacity: float = 1.0,
+) -> QgsMapLayer:
+    add_to_project = processing_output_should_load(parameters, context)
+    return add_or_update_ee_layer(
+        eeObject,
+        vis_params,
+        name,
+        shown,
+        opacity,
+        add_to_project=add_to_project,
+        context=None if add_to_project else context,
+    )
+
+
 def add_or_update_ee_raster_layer(
     image: ee.Image,
     name: str,
     vis_params: VisualizeParams,
     shown: bool = True,
     opacity: float = 1.0,
+    add_to_project: bool = True,
+    context: Optional[QgsProcessingContext] = None,
 ) -> QgsRasterLayer:
     logger.debug(f"Adding/updating EE raster layer: {name}")
-    layer = get_layer_by_name(name)
+    layer = get_layer_by_name(name) if add_to_project else None
     if layer and is_ee_layer(layer):
         return update_ee_image_layer(image, layer, vis_params, shown, opacity)
-    return add_ee_image_layer(image, name, vis_params, shown, opacity)
+    return add_ee_image_layer(
+        image, name, vis_params, shown, opacity, add_to_project, context
+    )
 
 
 def add_ee_image_layer(
@@ -312,6 +400,8 @@ def add_ee_image_layer(
     vis_params: VisualizeParams,
     shown: bool,
     opacity: float,
+    add_to_project: bool = True,
+    context: Optional[QgsProcessingContext] = None,
 ) -> QgsRasterLayer:
     logger.debug(f"Adding EE image layer: {name}")
     check_version()
@@ -320,10 +410,15 @@ def add_ee_image_layer(
     if not layer.isValid():
         raise RuntimeError(f"Failed to load layer: {name}")
     set_ee_layer_properties(layer, image, vis_params, layer_type="raster")
-    QgsProject.instance().addMapLayer(layer)
+    _store_created_layer(layer, add_to_project, context)
 
     if opacity is not None and layer.renderer():
         layer.renderer().setOpacity(opacity)
+
+    if add_to_project and shown is not None:
+        layer_node = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
+        if layer_node:
+            layer_node.setItemVisibilityChecked(shown)
 
     return layer
 
@@ -361,6 +456,8 @@ def add_or_update_named_vector_layer(
     vis_params: VisualizeParams,
     shown: bool = True,
     opacity: float = 1.0,
+    add_to_project: bool = True,
+    context: Optional[QgsProcessingContext] = None,
 ) -> QgsRasterLayer:
     logger.debug(f"Adding/updating named EE vector layer: {name}")
     table_id = eeObject.args.get("tableId", "")
@@ -381,10 +478,14 @@ def add_or_update_named_vector_layer(
         style_kwargs = {k: v for k, v in vis_params.items() if k in ee_style_keys}
         image = eeObject.style(**style_kwargs)
         # Style is already baked into the image; don't pass vis_params again
-        return add_or_update_ee_raster_layer(image, name, {}, shown, opacity)
+        return add_or_update_ee_raster_layer(
+            image, name, {}, shown, opacity, add_to_project, context
+        )
     else:
         image = ee.Image().paint(eeObject, 0, 2)
-        return add_or_update_ee_raster_layer(image, name, {}, shown, opacity)
+        return add_or_update_ee_raster_layer(
+            image, name, {}, shown, opacity, add_to_project, context
+        )
 
 
 def add_or_update_ee_vector_layer(
@@ -393,14 +494,18 @@ def add_or_update_ee_vector_layer(
     vis_params: Optional[dict] = None,
     shown: bool = True,
     opacity: float = 1.0,
+    add_to_project: bool = True,
+    context: Optional[QgsProcessingContext] = None,
 ) -> QgsVectorLayer:
     logger.debug(f"Adding/updating EE vector layer: {name}")
-    layer = get_layer_by_name(name)
+    layer = get_layer_by_name(name) if add_to_project else None
     if layer:
         if not layer.customProperty("ee-layer"):
             raise Exception(f"Layer is not an EE layer: {name}")
         return update_ee_vector_layer(eeObject, layer, vis_params, shown, opacity)
-    return add_ee_vector_layer(eeObject, name, vis_params, shown, opacity)
+    return add_ee_vector_layer(
+        eeObject, name, vis_params, shown, opacity, add_to_project, context
+    )
 
 
 def _geometry_type(name: str):
@@ -660,6 +765,8 @@ def add_ee_vector_layer(
     vis_params: Optional[dict] = None,
     shown: bool = True,
     opacity: float = 1.0,
+    add_to_project: bool = True,
+    context: Optional[QgsProcessingContext] = None,
 ) -> QgsVectorLayer:
     logger.debug(f"Adding EE vector layer: {name}")
     geojson = _ee_object_to_geojson(eeObject)
@@ -669,11 +776,11 @@ def add_ee_vector_layer(
         raise RuntimeError(f"Failed to load vector layer: {name}")
     set_ee_layer_properties(layer, eeObject, vis_params or {}, layer_type="vector")
 
-    QgsProject.instance().addMapLayer(layer)
+    _store_created_layer(layer, add_to_project, context)
     layer.setCustomProperty("ee-layer", True)
     layer.setCustomProperty("ee-vector-source", uri)
 
-    if shown is not None:
+    if add_to_project and shown is not None:
         tree_layer = QgsProject.instance().layerTreeRoot().findLayer(layer.id())
         if tree_layer:
             tree_layer.setItemVisibilityChecked(shown)


### PR DESCRIPTION
Create EE processing layers in the processing context when they should stay intermediate, while preserving visible layer loading for direct plugin runs. Update GeoTIFF export to resolve EE raster layers from temporary processing outputs as well as project layers.